### PR TITLE
fixed missing hash verification if using a new hash format in a nested mhl history

### DIFF
--- a/mhl/commands.py
+++ b/mhl/commands.py
@@ -486,7 +486,11 @@ def seal_file_path(existing_history, file_path, hash_format, session) -> (str, b
     relative_path = existing_history.get_relative_file_path(file_path)
     file_size = os.path.getsize(file_path)
     file_modification_date = datetime.datetime.fromtimestamp(os.path.getmtime(file_path))
-    existing_hash_formats = existing_history.find_existing_hash_formats_for_path(relative_path)
+
+    # find in the according child history the already available hash formats
+    existing_child_history, existing_history_relative_path = existing_history.find_history_for_path(relative_path)
+    existing_hash_formats = existing_child_history.find_existing_hash_formats_for_path(existing_history_relative_path)
+
     # in case there is no hash in the required format to use yet, we need to verify also against
     # one of the existing hash formats, we for simplicity use always the first hash format in this example
     # but one could also use a different one if desired

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -58,5 +58,5 @@ def test_nested_info(fs, nested_mhl_histories):
 
     runner = CliRunner()
     result = runner.invoke(mhl.commands.info, ['-sf', '/root/Stuff.txt'])
-    assert result.output == "Info with history at path: /root\nStuff.txt:\n  Generation 1 (2020-01-15T13:00:00+00:00) xxh64: 94c399c2a9a21f9a (original)\n  Generation 2 (2020-01-16T09:15:00+00:00) xxh64: 94c399c2a9a21f9a (verified)\n"
+    assert result.output == "Info with history at path: /root\nStuff.txt:\n  Generation 1 (2020-01-15T13:00:00+00:00) xxh64: 94c399c2a9a21f9a (original)\n  Generation 2 (2020-01-16T09:15:00+00:00) xxh64: 94c399c2a9a21f9a (verified)\n  Generation 3 (2020-01-16T09:15:00+00:00) xxh64: 94c399c2a9a21f9a (verified)\n  Generation 3 (2020-01-16T09:15:00+00:00) md5: 9eb84090956c484e32cb6c08455a667b (new)\n"
     assert result.exit_code == 0


### PR DESCRIPTION
we need to look for the existing hash formats in the child history of the file instead of the root history

also added a testcase to cover this case and adjusted expected result of info command test that was wrong before due to a failing mhl generation creation