### PR TITLE
Ignore Spec File Shorthand Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The `create` command hashes all files given with the different options and creat
 #### `create` default behavior (for file hierarchy, with completeness check)
 
 The `create` command traverses through a folder hierarchy (such as a folder with media files, a camera card, or an entire drive). The command hashes all files (not ignored by the given ignore patterns given with the `-i` or `-if` options) and the hashes are compared against records in the `ascmhl` folder. It records all hashed files in the new generation. Directory hashes are computed and also recorded in the new generation.
+The `create` command traverses through a folder hierarchy (such as a folder with media files, a camera card, or an entire drive). The command hashes all files (not ignored by the given ignore patterns given with the `-i` or `-ii` options) and the hashes are compared against records in the `ascmhl` folder. It records all hashed files in the new generation. Directory hashes are computed and also recorded in the new generation.
 
 The command detects, prints error, and exits with a non-0 exit code if it finds files that are registered in the `ascmhl` folder but that are missing in the file system. 
 
@@ -153,7 +154,7 @@ Files that are existent in the file system but are not registered in the `ascmhl
 The `create` command takes the root path of the file hierarchy as the parameter:
 
 ```
-$ ./ascmhl.py create [-i ignore pattern|-if /path/to/ignore-file.txt] /path/to/folder/
+$ ./ascmhl.py create [-i ignore pattern|-ii /path/to/ignore-file.txt] /path/to/folder/
 ```
 
 It works on folders with or without an `ascmhl` folder within the given folder hierarchy, and creates a new `ascmhl` folder at the given folder level if none is present before.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ The `create` command hashes all files given with the different options and creat
 
 #### `create` default behavior (for file hierarchy, with completeness check)
 
-The `create` command traverses through a folder hierarchy (such as a folder with media files, a camera card, or an entire drive). The command hashes all files (not ignored by the given ignore patterns given with the `-i` or `-if` options) and the hashes are compared against records in the `ascmhl` folder. It records all hashed files in the new generation. Directory hashes are computed and also recorded in the new generation.
 The `create` command traverses through a folder hierarchy (such as a folder with media files, a camera card, or an entire drive). The command hashes all files (not ignored by the given ignore patterns given with the `-i` or `-ii` options) and the hashes are compared against records in the `ascmhl` folder. It records all hashed files in the new generation. Directory hashes are computed and also recorded in the new generation.
 
 The command detects, prints error, and exits with a non-0 exit code if it finds files that are registered in the `ascmhl` folder but that are missing in the file system. 

--- a/mhl/commands.py
+++ b/mhl/commands.py
@@ -42,7 +42,7 @@ from .traverse import post_order_lexicographic
               type=click.Path(exists=True),
               help="Record single file, no completeness check (multiple occurrences possible for adding multiple files")
 @click.option('ignore_list', '--ignore', '-i', multiple=True, help="A single file pattern to ignore.")
-@click.option('ignore_spec_file', '--ignore_spec', type=click.Path(exists=True), help="A file containing multiple file patterns to ignore.")
+@click.option('ignore_spec_file', '--ignore_spec', '-ii', type=click.Path(exists=True), help="A file containing multiple file patterns to ignore.")
 def create(root_path, verbose, hash_format, no_directory_hashes, single_file, ignore_list, ignore_spec_file):
     """
     Create a new generation for a folder or file(s)
@@ -185,7 +185,7 @@ def create_for_single_files_subcommand(root_path, verbose, hash_format, no_direc
 @click.argument('root_path', type=click.Path(exists=True))
 @click.option('--verbose', '-v', default=False, is_flag=True, help="Verbose output")
 @click.option('ignore_list', '--ignore', '-i', multiple=True, help="A single file pattern to ignore.")
-@click.option('ignore_spec_file', '--ignore_spec', type=click.Path(exists=True), help="A file containing multiple file patterns to ignore.")
+@click.option('ignore_spec_file', '--ignore_spec', '-ii', type=click.Path(exists=True), help="A file containing multiple file patterns to ignore.")
 def verify(root_path, verbose, ignore_list, ignore_spec_file):
     """
     Verify a folder, single file(s), or a directory hash
@@ -280,7 +280,7 @@ def verify_entire_folder_against_full_history_subcommand(root_path, verbose, ign
 @click.argument('root_path', type=click.Path(exists=True))
 @click.option('--verbose', '-v', default=False, is_flag=True, help="Verbose output")
 @click.option('ignore_list', '--ignore', '-i', multiple=True, help="A single file pattern to ignore.")
-@click.option('ignore_spec_file', '--ignore_spec', type=click.Path(exists=True), help="A file containing multiple file patterns to ignore.")
+@click.option('ignore_spec_file', '--ignore_spec', '-ii', type=click.Path(exists=True), help="A file containing multiple file patterns to ignore.")
 def diff(root_path, verbose, ignore_list, ignore_spec_file):
     """
     Diff an entire folder structure
@@ -454,7 +454,7 @@ def xsd_schema_check(file_path):
 @click.option('--hash_format', '-h', type=click.Choice(ascmhl_supported_hashformats), multiple=False,
               default='xxh64', help="Algorithm")
 @click.option('ignore_list', '--ignore', '-i', multiple=True, help="A single file pattern to ignore.")
-@click.option('ignore_spec_file', '--ignore_spec', type=click.Path(exists=True), help="A file containing multiple file patterns to ignore.")
+@click.option('ignore_spec_file', '--ignore_spec', '-ii', type=click.Path(exists=True), help="A file containing multiple file patterns to ignore.")
 def directory_hash(root_path, verbose, hash_format, ignore_list, ignore_spec_file):
     """
     [TMP] Creates the directory hash of a given folder


### PR DESCRIPTION
I added a shorthand flag for the ignore spec file in the relevant commands, and updated the readme accordingly.