### PR TITLE
Fixes for chain xsd

### DIFF
--- a/xsd/ASCMHLChain.xsd
+++ b/xsd/ASCMHLChain.xsd
@@ -1,18 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<schema targetNamespace="urn:ASC:MHL:CHAIN:v2.0" elementFormDefault="qualified"
-    xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ascmhlchain="urn:ASC:MHL:CHAIN:v2.0">
-   <complexType name="ChainType">
-	    <sequence>
-		    <element name="ascmhlmanifest" type="ascmhlchain:AscMhlManifestType" maxOccurs="unbounded"/>
-	    </sequence>
-    </complexType>
-    <complexType name="AscMhlManifestType">
-	    <attribute name="sequencenr" type="integer"/>
-	    <sequence>
-		    <element name="path" type="string"/>
-		    <element name="c4" type="ascmhl:HashFormatType"/>
-	    </sequence>
-    </complexType>
-
-   	<element name=”ascmhlchain” type=”ascmhl:ChainType”>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<schema targetNamespace="urn:ASC:MHL:CHAIN:v2.0" 
+	xmlns="http://www.w3.org/2001/XMLSchema" 
+	xmlns:ascmhlchain="urn:ASC:MHL:CHAIN:v2.0" 
+	xmlns:ascmhl="urn:ASC:MHL:v2.0"  
+	elementFormDefault="qualified">
+		
+	<import schemaLocation="https://raw.githubusercontent.com/ascmitc/mhl/master/xsd/ASCMHL.xsd" namespace="urn:ASC:MHL:v2.0"/>
+	
+	<complexType name="ChainType">
+		<sequence>
+			<element name="ascmhlmanifest" type="ascmhlchain:AscMhlManifestType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="AscMhlManifestType">
+		<sequence>
+			<element name="path" type="string"/>
+			<element name="c4" type="ascmhl:HashFormatType"/>
+		</sequence>
+		<attribute name="sequencenr" type="integer"/>
+	</complexType>
+	<element name="ascmhlchain" type="ascmhlchain:ChainType"/>
 </schema>


### PR DESCRIPTION
- adding import of manifest xsd
- fixing minor namespace and syntax issues

The chain xsd now works with https://www.freeformatter.com/xml-validator-xsd.html and `xmllint`.