### PR TITLE
Improving doc for running ascmhl (via ascmhl.py) from repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ $ brew postinstall python3
 
 ```shell
 $ pip3 install -U git+https://github.com/ascmitc/mhl.git
+$ ascmhl --help
 ```
 
 ### Installing `ascmhl` manually
@@ -94,7 +95,14 @@ $ source env/bin/activate
 $ pip3 install -e .
 ```
 
-> As of now, this process has only been tested on macOS 10.13 and 10.14.
+You can use the `ascmhl.py` script located in `./mhl/cli/` in order to run `ascmhl` from the repository directly. Make sure to add the path of this repository's root directory to the `PYTHONPATH` environment variable.
+
+```shell
+$ export PYTHONPATH=$PYTHONPATH:/path/to/repository
+$ ./mhl/cli/ascmhl.py --help
+``` 
+
+> As of now, this process has been tested on macOS 10.13 and 10.14.
 
 
 ## Common Scenarios for `ascmhl`

--- a/ascmhl.py
+++ b/ascmhl.py
@@ -1,0 +1,1 @@
+mhl/cli/ascmhl.py


### PR DESCRIPTION
The refactorings for the installation via pip disabled the simple invocation of `ascmhl.py` from the command line.

* Adding symlink to ascmhl.py (to restore visibility of ascmhl.py in root directory) and 
* adding new requirements for running ascml.py (adding repo path PYTHONPATH) to README.
