### PR TITLE
Deploy to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+name: deploy
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest
+  deploy:
+    name: Build and publish Python distributions to PyPI
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out src from Git
+      uses: actions/checkout@v2
+    - name: Get history and tags for SCM versioning to work
+      run: |
+        git fetch --prune --unshallow
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ brew postinstall python3
 ### Installing / updating `ascmhl` as a user
 Please run the following command to install (or upgrade to) the latest development version of `ascmhl`:
 ```shell
-$ pip3 install --upgrade git+https://github.com/ascmitc/mhl.git
+$ pip3 install --upgrade ascmhl
 ```
 
 To verify that it has been correctly installed run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     dependency_links=[],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    name="mhl",
+    name="ascmhl",
     packages=find_packages(),
     setup_requires=["pytest-runner", "setuptools_scm"],
     tests_require=["pytest", "pyfakefs", "freezegun", "testfixtures"],


### PR DESCRIPTION
With this PR merged, a release can be published like this:

1. Tag a new version `git tag v0.3.1-beta.2`
2. `git push --tags`
3. Publish a new release using for example https://github.com/ascmitc/mhl/releases/new or clicking on the tag to edit and then filling out the title and changelog.

The third point could later be automated but for now I think it's ok or even preferable to have this manual step. There is some duplication in the workflow as I wanted to make sure the tests are again run before deployment and have not found a nice way to deduplicate so far.

To make this fully work, a repository secret called `PYPI_API_TOKEN` needs to be added. I can either add one from my account myself for now, or if you prefer, you can create a PyPI account which I can then give owner permission. With this you can then create you own API token.


/cc @ptrpfn @jwaggs 

Fixes #71 