### PR TITLE
Use package version

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -25,6 +25,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install package
+      run: |
+        pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install package
+      run: |
+        pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/mhl/__version__.py
+++ b/mhl/__version__.py
@@ -6,9 +6,13 @@ __license__ = "MIT"
 __maintainer__ = "Patrick Renner, Alexander Sahm"
 __email__ = "opensource@pomfort.com"
 """
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version  # noqa
 
-ascmhl_tool_name = "ascmhl.py"
-ascmhl_tool_version = "0.3 alpha"
+ascmhl_tool_name = "ascmhl"
+ascmhl_tool_version = version("ascmhl")
 
 ascmhl_folder_name = "ascmhl"
 ascmhl_file_extension = ".mhl"

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "pathspec>=0.8.0",
         "xattr>=0.9.6",
         "xxhash>=2.0.0",
+        "importlib-metadata>=4.0.1; python_version < '3.8'",
     ],
     dependency_links=[],
     long_description=long_description,

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -6,22 +6,30 @@ __license__ = "MIT"
 __maintainer__ = "Patrick Renner, Alexander Sahm"
 __email__ = "opensource@pomfort.com"
 """
+import difflib
+import filecmp
 import glob
-
-import pytest
 import os
 import shutil
-import filecmp
-import difflib
-from freezegun import freeze_time
-from click.testing import CliRunner
-from pyfakefs.fake_filesystem_unittest import Pause
+from importlib import reload
 from typing import List
+
+import pytest
+from click.testing import CliRunner
+from freezegun import freeze_time
+from pyfakefs.fake_filesystem_unittest import Pause
 
 import mhl.commands
 
 scenario_output_path = 'examples/scenarios/Output'
 fake_ref_root_path = '/ref'
+
+
+@pytest.fixture(autouse=True)
+def version(monkeypatch):
+    monkeypatch.setattr('mhl.__version__.ascmhl_tool_version', '0.3 alpha')
+    monkeypatch.setattr('mhl.__version__.ascmhl_tool_name', 'ascmhl.py')
+    reload(mhl.commands)
 
 
 @pytest.fixture()


### PR DESCRIPTION
This PR makes use of the package version instead of a hardcoded value. I monkey patched the version in the integration test for now.

Additionally the imports in `scenarios_test.py` have been ordered to match PEP 8 recommendations.

Depends on #73 