### PR TITLE
Updated XSDs to match spec draft v0.14

### DIFF
--- a/xsd/ASCMHL.xsd
+++ b/xsd/ASCMHL.xsd
@@ -36,7 +36,7 @@
 
     <complexType name="ProcessInfoType">
         <sequence>
-            <element name="roothash" type="ascmhl:HashType"/>
+            <element name="roothash" type="ascmhl:DirectoryHashType"/>
             <element name="process" type="ascmhl:ProcessType"/>
             <element name="ignore" type="ascmhl:IgnoreType" minOccurs="0"/>
         </sequence>
@@ -62,6 +62,7 @@
         <restriction base="string">
             <enumeration value="in-place"/>
             <enumeration value="transfer"/>
+            <enumeration value="flatten"/>
         </restriction>
     </simpleType>
     <complexType name="IgnoreType">
@@ -70,9 +71,10 @@
         </sequence>
     </complexType>
     <complexType name="HashesType">
-        <sequence>
+        <choice minOccurs="1" maxOccurs="unbounded">
             <element name="hash" type="ascmhl:HashType" maxOccurs="unbounded"/>
-        </sequence>
+            <element name="directoryhash" type="ascmhl:DirectoryHashType"/>
+        </choice>
     </complexType>
     <complexType name="HashType">
         <sequence>
@@ -99,7 +101,23 @@
             <element name="previousPath" type="string" minOccurs="0"/>
             <element minOccurs="0" name="metadata" type="ascmhl:MetadataType"/>
         </sequence>
-        <attribute name="directory" type="boolean"/>
+    </complexType>
+    <complexType name="DirectoryHashType">
+        <sequence>
+            <element name="path">
+                <complexType>
+                    <simpleContent>
+                        <extension base="string">
+                            <attribute name="creationdate" type="dateTime"/>
+                            <attribute name="lastmodificationdate" type="dateTime"/>
+                        </extension>
+                    </simpleContent>
+                </complexType>
+            </element>
+            <element name="content" type="ascmhl:DirectoryHashFormatContainerType" minOccurs="0"/>
+            <element name="structure" type="ascmhl:DirectoryHashFormatContainerType" minOccurs="0"/>
+            <element name="metadata" type="ascmhl:MetadataType" minOccurs="0"/>
+        </sequence>
     </complexType>
     <complexType name="HashFormatType">
         <simpleContent>
@@ -109,6 +127,16 @@
                 <attribute name="structure" type="string"/>
             </extension>
         </simpleContent>
+    </complexType>
+    <complexType name="DirectoryHashFormatContainerType">
+		<choice minOccurs="1" maxOccurs="unbounded">
+            <element name="md5" type="ascmhl:HashFormatType"/>
+            <element name="sha1" type="ascmhl:HashFormatType"/>
+            <element name="c4" type="ascmhl:HashFormatType"/>
+            <element name="xxh3" type="ascmhl:HashFormatType"/>
+            <element name="xxh64" type="ascmhl:HashFormatType"/>
+            <element name="xxh128" type="ascmhl:HashFormatType"/>
+        </choice>
     </complexType>
     <complexType name="ReferencesType">
         <sequence>

--- a/xsd/ASCMHL.xsd
+++ b/xsd/ASCMHL.xsd
@@ -13,6 +13,9 @@
             <enumeration value="failed"/>
         </restriction>
     </simpleType>
+    <simpleType name="RelativePathType">
+        <restriction base="string"/>
+    </simpleType>
     <complexType name="HashListType">
         <sequence>
             <element name="creatorinfo" type="ascmhl:CreatorInfoType"/>
@@ -36,8 +39,8 @@
 
     <complexType name="ProcessInfoType">
         <sequence>
-            <element name="roothash" type="ascmhl:DirectoryHashType"/>
             <element name="process" type="ascmhl:ProcessType"/>
+            <element name="roothash" type="ascmhl:RootDirectoryHashType" minOccurs="0"/>
             <element name="ignore" type="ascmhl:IgnoreType" minOccurs="0"/>
         </sequence>
     </complexType>
@@ -81,7 +84,7 @@
             <element name="path">
                 <complexType>
                     <simpleContent>
-                        <extension base="string">
+                        <extension base="ascmhl:RelativePathType">
                             <attribute name="size" type="integer"/>
                             <attribute name="creationdate" type="dateTime"/>
                             <attribute name="lastmodificationdate" type="dateTime"/>
@@ -98,7 +101,7 @@
                 <element name="xxh3" type="ascmhl:HashFormatType" maxOccurs="1" minOccurs="0"/>
                 <element name="xxh128" type="ascmhl:HashFormatType" maxOccurs="1" minOccurs="0"/>
             </choice>
-            <element name="previousPath" type="string" minOccurs="0"/>
+            <element name="previousPath" type="ascmhl:RelativePathType" minOccurs="0"/>
             <element minOccurs="0" name="metadata" type="ascmhl:MetadataType"/>
         </sequence>
     </complexType>
@@ -107,7 +110,7 @@
             <element name="path">
                 <complexType>
                     <simpleContent>
-                        <extension base="string">
+                        <extension base="ascmhl:RelativePathType">
                             <attribute name="creationdate" type="dateTime"/>
                             <attribute name="lastmodificationdate" type="dateTime"/>
                         </extension>
@@ -116,7 +119,14 @@
             </element>
             <element name="content" type="ascmhl:DirectoryHashFormatContainerType" minOccurs="0"/>
             <element name="structure" type="ascmhl:DirectoryHashFormatContainerType" minOccurs="0"/>
+            <element name="previousPath" type="ascmhl:RelativePathType" minOccurs="0"/>
             <element name="metadata" type="ascmhl:MetadataType" minOccurs="0"/>
+        </sequence>
+    </complexType>
+        <complexType name="RootDirectoryHashType">
+        <sequence>
+            <element name="content" type="ascmhl:DirectoryHashFormatContainerType"/>
+            <element name="structure" type="ascmhl:DirectoryHashFormatContainerType"/>
         </sequence>
     </complexType>
     <complexType name="HashFormatType">
@@ -146,7 +156,7 @@
     </complexType>
     <complexType name="HashListReferenceType">
         <sequence>
-            <element name="path" type="string"/>
+            <element name="path" type="ascmhl:RelativePathType"/>
             <element name="c4" type="ascmhl:HashFormatType"/>
         </sequence>
     </complexType>

--- a/xsd/ASCMHL.xsd
+++ b/xsd/ASCMHL.xsd
@@ -117,8 +117,8 @@
                     </simpleContent>
                 </complexType>
             </element>
-            <element name="content" type="ascmhl:DirectoryHashFormatContainerType" minOccurs="0"/>
-            <element name="structure" type="ascmhl:DirectoryHashFormatContainerType" minOccurs="0"/>
+            <element name="content" type="ascmhl:DirectoryHashFormatContainerType"/>
+            <element name="structure" type="ascmhl:DirectoryHashFormatContainerType"/>
             <element name="previousPath" type="ascmhl:RelativePathType" minOccurs="0"/>
             <element name="metadata" type="ascmhl:MetadataType" minOccurs="0"/>
         </sequence>

--- a/xsd/ASCMHLDirectory.xsd
+++ b/xsd/ASCMHLDirectory.xsd
@@ -14,7 +14,7 @@
 	</complexType>
 	<complexType name="HashlistType">
 		<sequence>
-			<element name="path" type="string"/>
+			<element name="path" type="ascmhl:RelativePathType"/>
 			<element name="c4" type="ascmhl:HashFormatType"/>
 		</sequence>
 		<attribute name="sequencenr" type="integer"/>

--- a/xsd/ASCMHLDirectory.xsd
+++ b/xsd/ASCMHLDirectory.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<schema targetNamespace="urn:ASC:MHL:CHAIN:v2.0" 
+<schema targetNamespace="urn:ASC:MHL:DIRECTORY:v2.0" 
 	xmlns="http://www.w3.org/2001/XMLSchema" 
-	xmlns:ascmhlchain="urn:ASC:MHL:CHAIN:v2.0" 
+	xmlns:ascmhldirectory="urn:ASC:MHL:DIRECTORY:v2.0" 
 	xmlns:ascmhl="urn:ASC:MHL:v2.0"  
 	elementFormDefault="qualified">
 		
 	<import schemaLocation="https://raw.githubusercontent.com/ascmitc/mhl/master/xsd/ASCMHL.xsd" namespace="urn:ASC:MHL:v2.0"/>
 	
-	<complexType name="ChainType">
+	<complexType name="DirectoryType">
 		<sequence>
-			<element name="ascmhlmanifest" type="ascmhlchain:AscMhlManifestType" maxOccurs="unbounded"/>
+			<element name="hashlist" type="ascmhldirectory:HashlistType" maxOccurs="unbounded"/>
 		</sequence>
 	</complexType>
-	<complexType name="AscMhlManifestType">
+	<complexType name="HashlistType">
 		<sequence>
 			<element name="path" type="string"/>
 			<element name="c4" type="ascmhl:HashFormatType"/>
 		</sequence>
 		<attribute name="sequencenr" type="integer"/>
 	</complexType>
-	<element name="ascmhlchain" type="ascmhlchain:ChainType"/>
+	<element name="ascmhldirectory" type="ascmhldirectory:DirectoryType"/>
 </schema>

--- a/xsd/examples/0001_TEST01_2019-10-11_155603.mhl
+++ b/xsd/examples/0001_TEST01_2019-10-11_155603.mhl
@@ -52,11 +52,11 @@
   </metadata>
   <references>
     <hashlistreference>
-      <path>A002R2EC/asc-mhl/A002R2EC_2020-01-17_143000_0002.mhl</path>
+      <path>A002R2EC/ascmhl/A002R2EC_2020-01-17_143000_0002.mhl</path>
       <c4>87210d6e0589c31c</c4>
     </hashlistreference>
     <hashlistreference>
-      <path>A003R2EC/asc-mhl/A003R2EC_2020-01-17_143000_0002.mhl</path>
+      <path>A003R2EC/ascmhl/A003R2EC_2020-01-17_143000_0002.mhl</path>
       <c4>40116e7da1ca1487</c4>
     </hashlistreference>
   </references>

--- a/xsd/examples/0001_TEST01_2019-10-11_155603.mhl
+++ b/xsd/examples/0001_TEST01_2019-10-11_155603.mhl
@@ -12,13 +12,15 @@
     <location>Munich, Germany</location>
   </creatorinfo>
   <processinfo>
+    <process>in-place</process>
     <roothash>
-      <path lastmodificationdate="2019-10-11T15:56:03+02:00">/Users/ptr/Development/MediaHashList/mhl/Scenarios/Output/scenario_01/A002R2EC/</path>
       <content>
         <c4>c44pdRyHLMvHsYbJnRpTrh5ohdWW6uVbm4mZx421aTN7y9MUKk74TqyshmTLgvnq2tcZex6khpxrYUq87Hczcmnyq3</c4>
       </content>
+      <structure>
+        <c4>c44pdRyHLMvHsYbJnRpTrh5ohdWW6uVbm4mZx421aTN7y9MUKk74TqyshmTLgvnq2tcZex6khpxrYUq87Hczcmnyq3</c4>
+      </structure>
     </roothash>
-    <process>in-place</process>
     <ignore>
       <pattern>*.DS_Store</pattern>      
       <pattern>/tmp</pattern>      

--- a/xsd/examples/0001_TEST01_2019-10-11_155603.mhl
+++ b/xsd/examples/0001_TEST01_2019-10-11_155603.mhl
@@ -12,9 +12,11 @@
     <location>Munich, Germany</location>
   </creatorinfo>
   <processinfo>
-    <roothash directory="true">
+    <roothash>
       <path lastmodificationdate="2019-10-11T15:56:03+02:00">/Users/ptr/Development/MediaHashList/mhl/Scenarios/Output/scenario_01/A002R2EC/</path>
-      <c4>c44pdRyHLMvHsYbJnRpTrh5ohdWW6uVbm4mZx421aTN7y9MUKk74TqyshmTLgvnq2tcZex6khpxrYUq87Hczcmnyq3</c4>
+      <content>
+        <c4>c44pdRyHLMvHsYbJnRpTrh5ohdWW6uVbm4mZx421aTN7y9MUKk74TqyshmTLgvnq2tcZex6khpxrYUq87Hczcmnyq3</c4>
+      </content>
     </roothash>
     <process>in-place</process>
     <ignore>
@@ -31,11 +33,13 @@
       <path size="5" lastmodificationdate="2019-10-11T15:56:03+02:00">Clips/A002C007_141024_R2EC.mov</path>
       <xxh64 action="original">7680e5f98f4a80fd</xxh64>
     </hash>
-    <hash directory="true">
+    <directoryhash>
       <path lastmodificationdate="2019-10-11T15:56:01+02:00">Clips/</path>
-      <xxh64>7680e5f98f4a80fd</xxh64>
+      <content>
+        <xxh64>7680e5f98f4a80fd</xxh64>
+      </content>
       <metadata>test2</metadata>
-    </hash>
+    </directoryhash>
     <hash>
       <path size="58" lastmodificationdate="2019-10-11T15:56:03+02:00">Sidecar.txt</path>
       <xxh64 action="failed">3ab5a4166b9bde44</xxh64>

--- a/xsd/examples/ascmhl_chain.xml
+++ b/xsd/examples/ascmhl_chain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ascmhlchain xmlns="urn:ASC:MHL:CHAIN:v2.0">
-    <ascmhlmanifest sequencenr="1">
+<ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
+    <hashlist sequencenr="1">
         <path>0001_TEST01_2019-10-11_155603.mhl</path>
         <c4>c44pdRyHLMvHsYbJnRpTrh5ohdWW6uVbm4mZx421aTN7y9MUKk74TqyshmTLgvnq2tcZex6khpxrYUq87Hczcmnyq3</c4>
-    </ascmhlmanifest>
-</ascmhlchain>
+    </hashlist>
+</ascmhldirectory>


### PR DESCRIPTION
- added directory hash types
- added flatten process type option
- renamed chain types for easier repurposing