### PR TITLE
fixing manifest filename to be UTC

### DIFF
--- a/ascmhl/utils.py
+++ b/ascmhl/utils.py
@@ -43,7 +43,7 @@ def datetime_now_isostring():
 
 def datetime_now_filename_string():
     """create a string representation for now() for use as part of the MHL filename"""
-    return datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%d_%H%M%S")
+    return datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y-%m-%d_%H%M%S")
 
 
 def datetime_now_isostring_with_microseconds():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+from packaging import version
+
+from ascmhl.utils import datetime_now_filename_string
+import datetime
+import os, time
+
+
+def test_time():
+    datetime_now_filename = datetime_now_filename_string()
+    datetime_now_filename_reference = datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y-%m-%d_%H%M%S")
+
+    print("datetime_now_filename:           " + datetime_now_filename)
+    print("datetime_now_filename_reference: " + datetime_now_filename_reference)
+
+    # seems always to be working, as tests run in UTC ?
+    assert datetime_now_filename == datetime_now_filename_reference


### PR DESCRIPTION
Fixing issue #95 (date in filename  should be in UTC, not local time zone)