### PR TITLE
Added options for calculating directory hashes only (no verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,16 @@ on error (including mismatching hashes):
 
 #### `verify` with `-dh` subcommand option (for directory hash)
 
-The `verify` command with the `-dh` subcommand option creates the directory hash by hashing the contained files of the given directory path (filtered by the ignore patterns from the `ascmhl` folder) and compares it with the to-be-expected directory hash calculated from the file hashes (same calculation as the `info` command with the `-dh` subcommand option).
+The `verify` command with the `-dh` subcommand (or `--directory_hash`) option creates the directory hash by hashing the contained files of the given directory path (filtered by the ignore patterns from the `ascmhl` folder) and compares it with the to-be-expected directory hash calculated from the file hashes (same calculation as the `info` command with the `-dh` subcommand option).
 
 
 ```
-$ ascmhl verify -dh /path/to/folder
+$ ascmhl verify -dh [-co [-ro]] /path/to/folder
 ```
+
+The `-co` option (or `--calculate_only`) only calculates and prints the directory hashes and doesn't verify them against an existing history. 
+This option also works when no history is present. The `-ro` option (or `--root_only`) only calculates and prints the root directory hash. This option is only in effect with the `-co` option.
+
 
 Implementation:
 

--- a/ascmhl/cli/ascmhl.py
+++ b/ascmhl/cli/ascmhl.py
@@ -42,9 +42,6 @@ mhltool_cli.add_command(commands.flatten)
 mhltool_cli.add_command(commands.info)
 mhltool_cli.add_command(commands.xsd_schema_check)
 
-# old
-mhltool_cli.add_command(commands.directory_hash, "dirhash")
-
 
 if __name__ == "__main__":
     mhltool_cli()

--- a/tests/test_dirhash.py
+++ b/tests/test_dirhash.py
@@ -1,0 +1,28 @@
+"""
+__author__ = "Patrick Renner"
+__copyright__ = "Copyright 2020, Pomfort GmbH"
+
+__license__ = "MIT"
+__maintainer__ = "Patrick Renner, Alexander Sahm"
+__email__ = "opensource@pomfort.com"
+"""
+
+import os
+from click.testing import CliRunner
+from freezegun import freeze_time
+
+import ascmhl.commands
+
+
+@freeze_time("2020-01-16 09:15:00")
+def test_simple(fs, simple_mhl_history):
+    runner = CliRunner()
+    result = runner.invoke(ascmhl.commands.verify, ["-dh", "-co", "/root/"])
+    assert "calculated directory hash for A  xxh64: 95e230e90be29dd6 (content), 997ef53a4365b87c (structure)" in result.output
+    assert "calculated root hash  xxh64: 36e824bc313f3b77 (content), 0b61ded93d2b71e6 (structure)" in result.output
+    assert result.exit_code == 0
+
+    result = runner.invoke(ascmhl.commands.verify, ["-dh", "-co", "-ro", "/root/"])
+    assert "calculated directory hash for A  xxh64: 95e230e90be29dd6 (content), 997ef53a4365b87c (structure)" not in result.output
+    assert "calculated root hash  xxh64: 36e824bc313f3b77 (content), 0b61ded93d2b71e6 (structure)" in result.output
+    assert result.exit_code == 0


### PR DESCRIPTION
Solving issue #96 by removing deprecated `dirhash` command and adding its features to the `verify` command. 

Also added tests and extended the README.