### PR TITLE
Adding support for multiple checksum formats for create command

### DIFF
--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -1384,28 +1384,75 @@ def seal_file_path(existing_history, file_path, hash_formats: [str], session) ->
     existing_child_history, existing_history_relative_path = existing_history.find_history_for_path(relative_path)
     existing_hash_formats = existing_child_history.find_existing_hash_formats_for_path(existing_history_relative_path)
 
-    current_hash_lookup = multiple_format_hash_file(file_path, hash_formats)
+    hash_formats_to_generate = hash_formats.copy()
+    newly_added_hash_formats = hash_formats.copy()
+
+    # if there are existing entries for this path, the recorded formats must also be generated even if they were not
+    # explicitly specified
+    if existing_hash_formats and len(existing_hash_formats) > 0:
+        newly_added_hash_formats = list(set(hash_formats_to_generate) - set(existing_hash_formats))
+
+        for hash_format in existing_hash_formats:
+            if hash_format not in hash_formats_to_generate:
+                hash_formats_to_generate.append(hash_format)
+
+    # generate the file hashes
+    current_hash_lookup = multiple_format_hash_file(file_path, hash_formats_to_generate)
+
     # in case there is no hash in the required format to use yet, we need to verify also against
     # one of the existing hash formats, we for simplicity use always the first hash format in this example
     # but one could also use a different one if desired
     hash_result_lookup = {}
-    for hash_format in hash_formats:
+
+    # each generated hash value must be added to the session.
+    # however, only the hash formats requested should be included in the returned hash lookup
+    for hash_format in hash_formats_to_generate:
         success = True
-        if len(existing_hash_formats) > 0 and hash_format not in existing_hash_formats:
-            existing_hash_format = existing_hash_formats[0]
-            hash_in_existing_format = hash_file(file_path, existing_hash_format)
-            # FIXME: test what happens if the existing hash verification fails in other format fails
-            # should we then really create two entries
-            success &= session.append_file_hash(
-                file_path, file_size, file_modification_date, existing_hash_format, hash_in_existing_format
-            )
-        current_format_hash = current_hash_lookup[hash_format]
-        # in case the existing hash verification failed we don't want to add the current format hash to the generation
-        # but we need to return it for directory hash creation
-        if success:
-            success &= session.append_file_hash(
-                file_path, file_size, file_modification_date, hash_format, current_format_hash
-            )
-        hash_result_lookup[hash_format] = SealPathResult(current_format_hash, success)
+        success &= session.append_file_hash(
+            file_path, file_size, file_modification_date, hash_format, current_hash_lookup[hash_format]
+        )
+
+        # If the existing hash was requested by the caller it needs to be added to the lookup
+        if hash_format in hash_formats:
+            hash_result_lookup[hash_format] = SealPathResult(current_hash_lookup[hash_format], success)
+
+    #if existing_hash_formats:
+    #    for hash_format in existing_hash_formats:
+    #        success = True
+    #        success &= session.append_file_hash(
+    #            file_path, file_size, file_modification_date, hash_format, current_hash_lookup[hash_format]
+    #        )
+    #
+    #        # If the existing hash was requested by the caller it needs to be added to the lookup
+    #        if hash_format in hash_formats:
+    #            hash_result_lookup[hash_format] = SealPathResult(current_hash_lookup[hash_format], success)
+    #if newly_added_hash_formats:
+    #    for hash_format in newly_added_hash_formats:
+    #        success = True
+    #        success &= session.append_file_hash(
+    #            file_path, file_size, file_modification_date, hash_format, current_hash_lookup[hash_format]
+    #        )
+    #        hash_result_lookup[hash_format] = SealPathResult(current_hash_lookup[hash_format], success)
+
+    #for hash_format in hash_formats:
+    #    success = True
+    #
+    #    #  If previous hashes were made and this format WAS NOT a part of the previous calculation
+    #    if len(existing_hash_formats) > 0 and hash_format not in existing_hash_formats:
+    #        existing_hash_format = existing_hash_formats[0]
+    #        hash_in_existing_format = hash_file(file_path, existing_hash_format)
+    #        # FIXME: test what happens if the existing hash verification fails in other format fails
+    #        # should we then really create two entries
+    #        success &= session.append_file_hash(
+    #            file_path, file_size, file_modification_date, existing_hash_format, hash_in_existing_format
+    #        )
+    #    current_format_hash = current_hash_lookup[hash_format]
+    #    # in case the existing hash verification failed we don't want to add the current format hash to the generation
+    #    # but we need to return it for directory hash creation
+    #    if success:
+    #        success &= session.append_file_hash(
+    #            file_path, file_size, file_modification_date, hash_format, current_format_hash
+    #        )
+    #    hash_result_lookup[hash_format] = SealPathResult(current_format_hash, success)
 
     return hash_result_lookup

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -560,8 +560,9 @@ def verify_entire_folder(
     if exception:
         raise exception
 
+
 def verify_directory_hash_subcommand(
-        root_path, verbose, hash_format, ignore_list=None, ignore_spec_file=None, calculate_only=False, root_only=False
+    root_path, verbose, hash_format, ignore_list=None, ignore_spec_file=None, calculate_only=False, root_only=False
 ):
     """
     Checks MHL directory hashes from all generations against computed directory hashes.
@@ -692,8 +693,8 @@ def verify_directory_hash_subcommand(
                         if not found_hash_format:
                             logger.error(
                                 f"ERROR: verification of folder {relative_path}: No directory hash of type"
-                             f" {hash_format} found"
-                             )
+                                f" {hash_format} found"
+                            )
                             num_failed_verifications += 1
                             add_detected_failure_for_format(directory_hash_entry.hash_format)
             else:
@@ -727,8 +728,9 @@ def verify_directory_hash_subcommand(
         if root_only and relative_path != ".":
             logger.verbose_logging = verbose
 
-        session.append_multiple_format_directory_hashes(folder_path, modification_date, dir_content_hash_lookup,
-                                                        dir_structure_hash_lookup)
+        session.append_multiple_format_directory_hashes(
+            folder_path, modification_date, dir_content_hash_lookup, dir_structure_hash_lookup
+        )
         logger.verbose_logging = verbose
 
         # compare root hashes, works differently
@@ -757,8 +759,8 @@ def verify_directory_hash_subcommand(
                         if not calculate_only:
                             if not found_hash_format:
                                 logger.error(
-                                    f"ERROR: verification of root folder: No directory hash of type {hash_format} "
-                                    f"found")
+                                    f"ERROR: verification of root folder: No directory hash of type {hash_format} found"
+                                )
     exception = None
 
     # check the failure lookup.  if even one format verified, consider the entire process verified
@@ -832,7 +834,7 @@ def _compare_and_log_directory_hashes(
 @click.command()
 @click.argument("file_path", type=click.Path(exists=True))
 @click.option(
-# FIXME: Update to permit multiple hash formats
+    # FIXME: Update to permit multiple hash formats
     "--hash_format",
     "-h",
     type=click.Choice(ascmhl_supported_hashformats),

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -43,6 +43,7 @@ from .traverse import post_order_lexicographic
     is_flag=True,
     help="Verbose output",
 )
+# FIXME: refactor to allow for multiple hash formats
 @click.option(
     "--hash_format",
     "-h",
@@ -220,6 +221,7 @@ def create_for_folder_subcommand(
         # generate directory hashes
         dir_hash_context = None
         if not no_directory_hashes:
+            # FIXME: refactor to allow for multiple hash formats
             dir_hash_context = DirectoryHashContext(hash_format)
         for item_name, is_dir in children:
             file_path = os.path.join(folder_path, item_name)
@@ -232,6 +234,7 @@ def create_for_folder_subcommand(
                         file_path, dir_content_hash_mappings.pop(file_path), dir_structure_hash_mappings.pop(file_path)
                     )
             else:
+                # FIXME: refactor to allow for multiple hash formats
                 hash_string, success = seal_file_path(existing_history, file_path, hash_format, session)
                 if not success:
                     num_failed_verifications += 1
@@ -245,6 +248,7 @@ def create_for_folder_subcommand(
             dir_content_hash_mappings[folder_path] = dir_content_hash
             dir_structure_hash_mappings[folder_path] = dir_structure_hash
         modification_date = datetime.datetime.fromtimestamp(os.path.getmtime(folder_path))
+        # FIXME: refactor to allow for multiple hash formats
         session.append_directory_hashes(
             folder_path, modification_date, hash_format, dir_content_hash, dir_structure_hash
         )
@@ -311,10 +315,12 @@ def create_for_single_files_subcommand(
                     file_path = os.path.join(folder_path, item_name)
                     if is_dir:
                         continue
+                    # FIXME: refactor to allow for multiple hash formats
                     _, success = seal_file_path(existing_history, file_path, hash_format, session)
                     if not success:
                         num_failed_verifications += 1
         else:
+            # FIXME: refactor to allow for multiple hash formats
             _, success = seal_file_path(existing_history, path, hash_format, session)
             if not success:
                 num_failed_verifications += 1
@@ -549,6 +555,7 @@ def verify_directory_hash_subcommand(
 
     # choose the hash format of the latest root directory hash
     if hash_format is None:
+        # FIXME: refactor to allow for multiple hash formats
         generation = -1
         for hash_list in existing_history.hash_lists:
             if hash_list.generation_number > generation:
@@ -573,6 +580,7 @@ def verify_directory_hash_subcommand(
     for folder_path, children in post_order_lexicographic(root_path, ignore_spec.get_path_spec()):
         # generate directory hashes
         dir_hash_context = None
+        # FIXME: refactor to allow for multiple hash formats
         dir_hash_context = DirectoryHashContext(hash_format)
         for item_name, is_dir in children:
             file_path = os.path.join(folder_path, item_name)
@@ -589,6 +597,7 @@ def verify_directory_hash_subcommand(
 
                 num_successful_verifications = 0
                 found_hash_format = False
+                # FIXME: refactor to allow for multiple hash formats
                 for directory_hash_entry in directory_hash_entries:
                     if directory_hash_entry.hash_format != hash_format:
                         continue
@@ -1208,7 +1217,7 @@ def commit_session_for_collection(
 
     session.commit(creator_info, process_info)
 
-
+# FIXME: refactor to allow for multiple hash formats
 def seal_file_path(existing_history, file_path, hash_format, session) -> (str, bool):
     relative_path = existing_history.get_relative_file_path(file_path)
     file_size = os.path.getsize(file_path)

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -218,6 +218,10 @@ def create_for_folder_subcommand(
     # store the directory hashes of sub folders so we can use it when calculating the hash of the parent folder
     dir_content_hash_mappings = {}
     dir_structure_hash_mappings = {}
+
+    # TODO: Remove once the function signature is updated to supply a hash format list instead of a single format
+    hash_format_list = [hash_format]
+
     for folder_path, children in post_order_lexicographic(root_path, session.ignore_spec.get_path_spec()):
         # generate directory hashes
         dir_hash_context = None
@@ -310,6 +314,9 @@ def create_for_single_files_subcommand(
     session = MHLGenerationCreationSession(existing_history)
 
     num_failed_verifications = 0
+    # TODO: Remove once the function signature is updated to supply a hash format list instead of a single format
+    hash_format_list = [hash_format]
+
     for path in single_file:
         if not os.path.isabs(path):
             path = os.path.join(os.getcwd(), path)
@@ -319,12 +326,12 @@ def create_for_single_files_subcommand(
                     file_path = os.path.join(folder_path, item_name)
                     if is_dir:
                         continue
-                    seal_result = seal_file_path(existing_history, file_path, [hash_format], session)
+                    seal_result = seal_file_path(existing_history, file_path, hash_format_list, session)
                     success = seal_result[hash_format].success
                     if not success:
                         num_failed_verifications += 1
         else:
-            seal_result = seal_file_path(existing_history, file_path, [hash_format], session)
+            seal_result = seal_file_path(existing_history, file_path, hash_format_list, session)
             success = seal_result[hash_format].success
             if not success:
                 num_failed_verifications += 1

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -611,8 +611,8 @@ def verify_directory_hash_subcommand(
 
     # start a verification session on the existing history
     hash_format_list = sorted(hash_formats)
-    # a lookup containing the number of failures detected per hash format
-    failures_per_format_lookup = dict[str, int]()
+    # a lookup containing the number of failures detected per hash format - will match the format Dict[str, int]
+    failures_per_format_lookup = {}
 
     # an inner function responsible for adding format failures to the lookup
     def add_detected_failure_for_format(failed_hash_format):
@@ -632,8 +632,8 @@ def verify_directory_hash_subcommand(
     dir_content_hash_mappings = {}
     dir_structure_hash_mappings = {}
     for folder_path, children in post_order_lexicographic(root_path, ignore_spec.get_path_spec()):
-        # generate directory hashes
-        dir_hash_context_lookup = dict[str, DirectoryHashContext]()
+        # generate directory hashes - will match the format dict[str, DirectoryHashContext]
+        dir_hash_context_lookup = {}
 
         # create a DirectoryHashContext for each hash format and store in the lookup
         for hash_format in hash_format_list:

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -34,6 +34,7 @@ from .traverse import post_order_lexicographic
 from typing import Dict
 from collections import namedtuple
 
+
 @click.command()
 @click.argument("root_path", type=click.Path(exists=True))
 # general options
@@ -236,7 +237,11 @@ def create_for_folder_subcommand(
             if is_dir:
                 if not no_directory_hashes:
                     for hash_format, dir_hash_context in dir_hash_context_lookup.items():
-                        dir_hash_context.append_directory_hashes(file_path, dir_content_hash_mappings.pop(file_path), dir_structure_hash_mappings.pop(file_path))
+                        dir_hash_context.append_directory_hashes(
+                            file_path,
+                            dir_content_hash_mappings.pop(file_path),
+                            dir_structure_hash_mappings.pop(file_path),
+                        )
             else:
                 seal_result = seal_file_path(existing_history, file_path, hash_format_list, session)
 
@@ -269,10 +274,9 @@ def create_for_folder_subcommand(
 
         modification_date = datetime.datetime.fromtimestamp(os.path.getmtime(folder_path))
         # FIXME: refactor to allow for multiple hash formats
-        session.append_multiple_format_directory_hashes(folder_path,
-                                                        modification_date,
-                                                        dir_content_hash_lookup,
-                                                        dir_structure_hash_lookup)
+        session.append_multiple_format_directory_hashes(
+            folder_path, modification_date, dir_content_hash_lookup, dir_structure_hash_lookup
+        )
 
     commit_session(session, author_name, author_email, author_phone, author_role, location, comment)
 
@@ -1266,13 +1270,10 @@ attributes:
 hash_value -- string value, a hash
 success -- boolean value, indicates if the update was successful
 """
-SealPathResult = namedtuple('SealPathResult', ['hash_value', 'success'])
+SealPathResult = namedtuple("SealPathResult", ["hash_value", "success"])
 
 
-def seal_file_path(existing_history,
-                   file_path,
-                   hash_formats: [str],
-                   session) -> Dict[str, SealPathResult]:
+def seal_file_path(existing_history, file_path, hash_formats: [str], session) -> Dict[str, SealPathResult]:
     """
     Generates hashes for a file path.
     Compares the generated hashes to any existing hash records
@@ -1311,11 +1312,9 @@ def seal_file_path(existing_history,
         # in case the existing hash verification failed we don't want to add the current format hash to the generation
         # but we need to return it for directory hash creation
         if success:
-            success &= session.append_file_hash(file_path,
-                                                file_size,
-                                                file_modification_date,
-                                                hash_format,
-                                                current_format_hash)
+            success &= session.append_file_hash(
+                file_path, file_size, file_modification_date, hash_format, current_format_hash
+            )
         hash_result_lookup[hash_format] = SealPathResult(current_format_hash, success)
 
     return hash_result_lookup

--- a/ascmhl/generator.py
+++ b/ascmhl/generator.py
@@ -79,7 +79,7 @@ class MHLGenerationCreationSession:
                 if existing_hash_entry is not None:
                     if existing_hash_entry.hash_string == hash_string:
                         hash_entry.action = "verified"
-                        logger.verbose(f"  verified                      {relative_path}  OK")
+                        logger.verbose(f"  verified                      {relative_path} {hash_format}: OK")
                     else:
                         hash_entry.action = "failed"
                         failures += 1
@@ -93,9 +93,7 @@ class MHLGenerationCreationSession:
                     hash_entry.action = (  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
                         "new"
                     )
-                    logger.verbose(
-                        f"  created new, verified hash for          {relative_path}  {hash_format}: {hash_string}"
-                    )
+                    logger.verbose(f"  created new (verif.) hash for {relative_path}  {hash_format}: {hash_string}")
             # collection behavior: overwrite action with action from flattened history
             if action != None:
                 hash_entry.action = action
@@ -140,7 +138,7 @@ class MHLGenerationCreationSession:
             if existing_hash_entry is not None:
                 if existing_hash_entry.hash_string == hash_string:
                     hash_entry.action = "verified"
-                    logger.verbose(f"  verified                      {relative_path}  OK")
+                    logger.verbose(f"  verified                      {relative_path}  {hash_format}: OK")
                 else:
                     hash_entry.action = "failed"
                     logger.error(
@@ -151,9 +149,7 @@ class MHLGenerationCreationSession:
             else:
                 # in case there is no hash entry for this hash format yet
                 hash_entry.action = "new"  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
-                logger.verbose(
-                    f"  created new, verified hash for          {relative_path}  {hash_format}: {hash_string}"
-                )
+                logger.verbose(f"  created new (verif.) hash for {relative_path}  {hash_format}: {hash_string}")
 
         # in case the same file is hashes multiple times we want to add all hash entries
         new_hash_list = self.new_hash_lists[history]

--- a/ascmhl/generator.py
+++ b/ascmhl/generator.py
@@ -15,6 +15,7 @@ from . import logger
 from .ignore import MHLIgnoreSpec
 from .hashlist import MHLHashList, MHLHashEntry, MHLCreatorInfo, MHLProcessInfo
 from .history import MHLHistory
+from .hasher import HashPair
 
 
 class MHLGenerationCreationSession:
@@ -40,6 +41,85 @@ class MHLGenerationCreationSession:
         self.root_history = history
         self.new_hash_lists = defaultdict(MHLHashList)
         self.ignore_spec = ignore_spec
+
+    def append_file_hashes(self,
+                           file_path,
+                           file_size,
+                           hash_pairs: [HashPair],
+                           file_modification_date,
+                           action=None,
+                           hash_date=None) -> bool:
+        """
+        Adds file hashes to the history
+        :param file_path: a string value representing the path to a file
+        :param file_size: size of the file path in bytes
+        :param hash_pairs: an array of hash values
+        :param file_modification_date: date the file was last modified
+        :param action: a predetermined action for the entry.  defaults to none
+        :param hash_date: date the hashes were generated
+        :return a bool indicating if the hashes were successfully appended.  returns false if any failures occur
+        """
+        relative_path = self.root_history.get_relative_file_path(file_path)
+        # TODO: handle if path is outside of history root path
+        # Keep track of the number of failures
+        failures = 0
+        history, history_relative_path = self.root_history.find_history_for_path(relative_path)
+        # for collections we cannot create a valid relative path (we are in the "wrong" history), but in that case
+        # the file_path is inputted already as the relative path (a bit of implicit functionality here)
+        if history_relative_path == None:
+            history_relative_path = file_path
+
+        # check if there is an existing hash in the other generations and verify
+        original_hash_entry = history.find_original_hash_entry_for_path(history_relative_path)
+
+        hash_entries = [MHLHashEntry]
+
+        for pair in hash_pairs:
+            hash_format = pair.hash_format
+            hash_string = pair.hash_string
+
+            hash_entry = MHLHashEntry(hash_format, hash_string, hash_date=hash_date)
+            if original_hash_entry is None:
+                hash_entry.action = "original"
+                logger.verbose(f"  created original hash for     {relative_path}  {hash_format}: {hash_string}")
+            else:
+                existing_hash_entry = history.find_first_hash_entry_for_path(history_relative_path, hash_format)
+                if existing_hash_entry is not None:
+                    if existing_hash_entry.hash_string == hash_string:
+                        hash_entry.action = "verified"
+                        logger.verbose(f"  verified                      {relative_path}  OK")
+                    else:
+                        hash_entry.action = "failed"
+                        failures += 1
+                        logger.error(
+                            f"ERROR: hash mismatch for        {relative_path}  "
+                            f"{hash_format} (old): {existing_hash_entry.hash_string}, "
+                            f"{hash_format} (new): {hash_string}"
+                        )
+                else:
+                    # in case there is no hash entry for this hash format yet
+                    hash_entry.action = "new"  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
+                    logger.verbose(
+                        f"  created new, verified hash for          {relative_path}  {hash_format}: {hash_string}"
+                    )
+            # collection behavior: overwrite action with action from flattened history
+            if action != None:
+                hash_entry.action = action
+
+            # Add the generated entry to the list
+            hash_entries.append(hash_entry)
+
+        # in case the same file is hashes multiple times we want to add all hash entries
+        new_hash_list = self.new_hash_lists[history]
+        media_hash = new_hash_list.find_or_create_media_hash_for_path(
+            history_relative_path, file_size, file_modification_date
+        )
+
+        # Add the new hash entries
+        for hash_entry in hash_entries:
+            media_hash.append_hash_entry(hash_entry)
+
+        return failures == 0
 
     def append_file_hash(
         self, file_path, file_size, file_modification_date, hash_format, hash_string, action=None, hash_date=None
@@ -93,6 +173,81 @@ class MHLGenerationCreationSession:
 
         media_hash.append_hash_entry(hash_entry)
         return hash_entry.action != "failed"
+
+    def append_directory_hashes(self,
+                                path,
+                                modification_date,
+                                content_hashes: [HashPair],
+                                structure_hashes: [HashPair]) -> None:
+        """
+        Adds directory hashes to the history
+        :param path: a string value representing the path to a file
+        :param modification_date: date the file was last modified
+        :param content_hashes: an array of content hash pairs
+        :param structure_hashes: an array of structure hash pairs
+        :return: none
+        """
+        relative_path = self.root_history.get_relative_file_path(path)
+        # TODO: handle if path is outside of history root path
+
+        history, history_relative_path = self.root_history.find_history_for_path(relative_path)
+
+        # in case the same file is hashes multiple times we want to add all hash entries
+        new_hash_list = self.new_hash_lists[history]
+        media_hash = new_hash_list.find_or_create_media_hash_for_path(history_relative_path, None, modification_date)
+        media_hash.is_directory = True
+
+        # Break the structure hashes down into a lookup
+        structure_lookup = dict[str, str]
+        if structure_hashes:
+            for structure_pair in structure_hashes:
+                structure_lookup[structure_pair.hash_format] = structure_pair.hash_value
+
+        # Add the content entries
+        if content_hashes:
+            for hash_pair in content_hashes:
+                # Add the content entry
+                hash_format = hash_pair.hash_format
+                content_hash_string = hash_pair.hash_string
+                structure_hash_string = structure_lookup[hash_format]
+
+                hash_entry = MHLHashEntry(hash_format, content_hash_string)
+                # Attempt to add the structure, if available
+                hash_entry.structure_hash_string = structure_hash_string
+                media_hash.append_hash_entry(hash_entry)
+
+                if relative_path == ".":
+                    logger.verbose(
+                        f"  calculated root hash  {hash_format}: "
+                        f"{content_hash_string} (content), "
+                        f"{structure_hash_string} (structure)"
+                    )
+                else:
+                    logger.verbose(
+                        f"  calculated directory hash for {relative_path}  {hash_format}: "
+                        f"{content_hash_string} (content), "
+                        f"{structure_hash_string} (structure)"
+                    )
+        else:
+            logger.verbose(f"  added directory entry for     {relative_path}")
+
+        # in case we just created the root media hash of the current hash list we also add it one history level above
+        if new_hash_list.process_info.root_media_hash is media_hash and history.parent_history:
+            parent_history = history.parent_history
+            parent_relative_path = parent_history.get_relative_file_path(path)
+            parent_hash_list = self.new_hash_lists[parent_history]
+            parent_media_hash = parent_hash_list.find_or_create_media_hash_for_path(
+                parent_relative_path, None, modification_date
+            )
+            parent_media_hash.is_directory = True
+            if content_hashes:
+                for hash_pair in content_hashes:
+                    hash_format = hash_pair.hash_format
+                    content_hash_string = hash_pair.hash_string
+                    structure_hash_string = structure_lookup[hash_format]
+                    hash_entry = MHLHashEntry(hash_format, content_hash_string)
+                    hash_entry.structure_hash_string = structure_hash_string
+                    parent_media_hash.append_hash_entry(hash_entry)
 
     def append_directory_hashes(
         self, path, modification_date, hash_format, content_hash_string, structure_hash_string

--- a/ascmhl/generator.py
+++ b/ascmhl/generator.py
@@ -41,13 +41,9 @@ class MHLGenerationCreationSession:
         self.new_hash_lists = defaultdict(MHLHashList)
         self.ignore_spec = ignore_spec
 
-    def append_multiple_format_file_hashes(self,
-                                           file_path,
-                                           file_size,
-                                           hash_lookup: Dict[str, str],
-                                           file_modification_date,
-                                           action=None,
-                                           hash_date=None) -> bool:
+    def append_multiple_format_file_hashes(
+        self, file_path, file_size, hash_lookup: Dict[str, str], file_modification_date, action=None, hash_date=None
+    ) -> bool:
         """
         Adds file hashes to the history
         :param file_path: a string value representing the path to a file
@@ -94,7 +90,9 @@ class MHLGenerationCreationSession:
                         )
                 else:
                     # in case there is no hash entry for this hash format yet
-                    hash_entry.action = "new"  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
+                    hash_entry.action = (  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
+                        "new"
+                    )
                     logger.verbose(
                         f"  created new, verified hash for          {relative_path}  {hash_format}: {hash_string}"
                     )
@@ -170,11 +168,9 @@ class MHLGenerationCreationSession:
         media_hash.append_hash_entry(hash_entry)
         return hash_entry.action != "failed"
 
-    def append_multiple_format_directory_hashes(self,
-                                                path,
-                                                modification_date,
-                                                content_hash_lookup: Dict[str, str],
-                                                structure_hash_lookup: Dict[str, str]) -> None:
+    def append_multiple_format_directory_hashes(
+        self, path, modification_date, content_hash_lookup: Dict[str, str], structure_hash_lookup: Dict[str, str]
+    ) -> None:
         """
         Adds directory hashes to the history
         :param path: a string value representing the path to a file

--- a/ascmhl/hasher.py
+++ b/ascmhl/hasher.py
@@ -449,7 +449,7 @@ def multiple_format_hash_data(input_data: bytes,
     hash_formats -- string values, each entry is one of the supported hash formats, e.g. 'md5', 'xxh64'
     """
     hash_aggregate = AggregateHasher()
-    return hash_aggregate.hash_data(bytes, hash_formats)
+    return hash_aggregate.hash_data(input_data, hash_formats)
 
 
 def bytes_for_hash_string(hash_string: str, hash_format: str) -> bytes:

--- a/ascmhl/hasher.py
+++ b/ascmhl/hasher.py
@@ -16,26 +16,6 @@ from abc import ABC, abstractmethod
 from typing import Dict
 
 
-class HashPair:
-    """
-    HashPair is an explict coupling of a hash value to a defined hash format
-    """
-    def __init__(self, hash_format: str, hash_string: str):
-        """
-        Initializes the pair
-        :param hash_format: string value, one of the supported hash formats, e.g. 'md5', 'xxh64'
-        :param hash_string: A hash string computed from the supplied format
-        """
-        if not hash_format:
-            raise ValueError
-        hash_type = HashType[hash_format]
-        if not hash_type:
-            raise ValueError
-
-        self.hash_format = hash_format
-        self.hash_value = hash_string
-
-
 class Hasher(ABC):
     """
     Hasher is an abstract base class (ABC) that outlines the needed hash functionality by ascmhl.

--- a/ascmhl/hasher.py
+++ b/ascmhl/hasher.py
@@ -227,6 +227,7 @@ class C4(Hasher):
         data = result.to_bytes(64, byteorder="big")
         return data
 
+
 @unique
 class HashType(Enum):
     """
@@ -243,7 +244,6 @@ class HashType(Enum):
 
 
 class AggregateHasher:
-
     def __init__(self, hash_formats: [str]):
 
         # Build a hasher for each format
@@ -257,10 +257,9 @@ class AggregateHasher:
     """
     Handles multiple hashing to facilitate a read-once create-many hashing paradigm
     """
+
     @classmethod
-    def hash_file(cls, 
-                  file_path: str,
-                  hash_formats: [str]) -> Dict[str, str]:
+    def hash_file(cls, file_path: str, hash_formats: [str]) -> Dict[str, str]:
         """
         computes and returns new hash strings for a file
 
@@ -295,9 +294,7 @@ class AggregateHasher:
         return hash_output_lookup
 
     @classmethod
-    def hash_data(cls, 
-                  input_data: bytes, 
-                  hash_formats: [str]) -> Dict[str, str]:
+    def hash_data(cls, input_data: bytes, hash_formats: [str]) -> Dict[str, str]:
         """
         computes and returns new hash strings for a file
 
@@ -394,15 +391,14 @@ def hash_of_hash_list(hash_list: [str], hash_format: str) -> str:
     return hasher.hash_of_hash_list(hash_list)
 
 
-def multiple_format_hash_file(file_path: str,
-                              hash_formats: [str]) -> Dict[str, str]:
+def multiple_format_hash_file(file_path: str, hash_formats: [str]) -> Dict[str, str]:
     """
-     computes and returns a new hash strings for a file
+    computes and returns a new hash strings for a file
 
-     arguments:
-     file_path -- string value, path of file to generate hash for.
-     hash_formats -- string values, each entry is one of the supported hash formats, e.g. 'md5', 'xxh64'
-     """
+    arguments:
+    file_path -- string value, path of file to generate hash for.
+    hash_formats -- string values, each entry is one of the supported hash formats, e.g. 'md5', 'xxh64'
+    """
     return AggregateHasher.hash_file(file_path, hash_formats)
 
 
@@ -430,8 +426,7 @@ def hash_data(input_data: bytes, hash_format: str) -> str:
     return hasher.hash_data(input_data)
 
 
-def multiple_format_hash_data(input_data: bytes,
-                              hash_formats: [str]) -> Dict[str, str]:
+def multiple_format_hash_data(input_data: bytes, hash_formats: [str]) -> Dict[str, str]:
     """
     computes and returns new hash strings from the input data
     arguments:

--- a/ascmhl/hasher.py
+++ b/ascmhl/hasher.py
@@ -403,8 +403,8 @@ def hash_of_hash_list(hash_list: [str], hash_format: str) -> str:
     return hasher.hash_of_hash_list(hash_list)
 
 
-def hash_file(file_path: str,
-              hash_formats: [str]) -> [HashPair]:
+def multiple_format_hash_file(file_path: str,
+                              hash_formats: [str]) -> [HashPair]:
     """
      computes and returns a new hash strings for a file
 
@@ -440,8 +440,8 @@ def hash_data(input_data: bytes, hash_format: str) -> str:
     return hasher.hash_data(input_data)
 
 
-def hash_data(input_data: bytes,
-              hash_formats: [str]) -> [HashPair]:
+def multiple_format_hash_data(input_data: bytes,
+                              hash_formats: [str]) -> [HashPair]:
     """
     computes and returns new hash strings from the input data
     arguments:

--- a/examples/scenarios/Output/scenario_02/log.txt
+++ b/examples/scenarios/Output/scenario_02/log.txt
@@ -25,10 +25,10 @@ this will verify all hashes, check for completeness and create a second generati
 
 $ ascmhl.py create -v /file_server/A002R2EC -h xxh64
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
-  verified                      Sidecar.txt  OK
+  verified                      Sidecar.txt  xxh64: OK
   calculated root hash  xxh64: 8d02114c32e28cbe (content), f557f8ca8e5a88ef (structure)
 Created new generation ascmhl/0002_A002R2EC_2020-01-17_143000.mhl
 

--- a/examples/scenarios/Output/scenario_03/log.txt
+++ b/examples/scenarios/Output/scenario_03/log.txt
@@ -28,13 +28,13 @@ and create a second generation with additional (new) MD5 hashes.
 
 $ ascmhl.py create -v -h md5 /file_server/A002R2EC
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  created new, verified hash for          Clips/A002C006_141024_R2EC.mov  md5: f5ac8127b3b6b85cdc13f237c6005d80
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
-  created new, verified hash for          Clips/A002C007_141024_R2EC.mov  md5: 614dd0e977becb4c6f7fa99e64549b12
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  created new (verif.) hash for Clips/A002C006_141024_R2EC.mov  md5: f5ac8127b3b6b85cdc13f237c6005d80
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
+  created new (verif.) hash for Clips/A002C007_141024_R2EC.mov  md5: 614dd0e977becb4c6f7fa99e64549b12
   calculated directory hash for Clips  md5: 202a2d71b56b080d9b089c1f4f29a4ba (content), 4a739024fd19d928e9dea6bb5c480200 (structure)
-  verified                      Sidecar.txt  OK
-  created new, verified hash for          Sidecar.txt  md5: 6425c5a180ca0f420dd2b25be4536a91
+  verified                      Sidecar.txt  xxh64: OK
+  created new (verif.) hash for Sidecar.txt  md5: 6425c5a180ca0f420dd2b25be4536a91
   calculated root hash  md5: 6fae2da9bc6dca45486cb91bfea6db70 (content), be1f2eaed208efbed061845a64cacdfa (structure)
 Created new generation ascmhl/0002_A002R2EC_2020-01-17_143000.mhl
 

--- a/examples/scenarios/Output/scenario_04/log.txt
+++ b/examples/scenarios/Output/scenario_04/log.txt
@@ -29,8 +29,8 @@ An error is shown and create a new generation that documents the failed verifica
 
 $ ascmhl.py create -v /file_server/A002R2EC -h xxh64
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
 ERROR: hash mismatch for        Sidecar.txt  xxh64 (old): 3ab5a4166b9bde44, xxh64 (new): 70d2cf31aaa3eac4
   calculated root hash  xxh64: 8e52e9c3d15e055c (content), 32706d5f4b48f047 (structure)

--- a/examples/scenarios/Output/scenario_05/log.txt
+++ b/examples/scenarios/Output/scenario_05/log.txt
@@ -45,15 +45,15 @@ of the card sub folders.
 
 $ ascmhl.py create -v /file_server/Reels -h xxh64
 Creating new generation for folder at path: /file_server/Reels ...
-  verified                      A002R2EC/Clips/A002C006_141024_R2EC.mov  OK
-  verified                      A002R2EC/Clips/A002C007_141024_R2EC.mov  OK
+  verified                      A002R2EC/Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      A002R2EC/Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for A002R2EC/Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
-  verified                      A002R2EC/Sidecar.txt  OK
+  verified                      A002R2EC/Sidecar.txt  xxh64: OK
   calculated directory hash for A002R2EC  xxh64: 8d02114c32e28cbe (content), f557f8ca8e5a88ef (structure)
-  verified                      A003R2EC/Clips/A003C011_141024_R2EC.mov  OK
-  verified                      A003R2EC/Clips/A003C012_141024_R2EC.mov  OK
+  verified                      A003R2EC/Clips/A003C011_141024_R2EC.mov  xxh64: OK
+  verified                      A003R2EC/Clips/A003C012_141024_R2EC.mov  xxh64: OK
   calculated directory hash for A003R2EC/Clips  xxh64: f2afc6434255a53d (content), a25d5ca89c95f9e2 (structure)
-  verified                      A003R2EC/Sidecar.txt  OK
+  verified                      A003R2EC/Sidecar.txt  xxh64: OK
   calculated directory hash for A003R2EC  xxh64: 7a82373c131cf40a (content), 1131a950fcc55e4b (structure)
   created original hash for     Summary.txt  xxh64: 0ac48e431d4538ba
   calculated root hash  xxh64: 92950bc8fda076ec (content), 2c2ce52605558158 (structure)

--- a/examples/scenarios/README.md
+++ b/examples/scenarios/README.md
@@ -52,10 +52,10 @@ this will verify all hashes, check for completeness and create a second generati
 
 $ ascmhl.py create -v /file_server/A002R2EC -h xxh64
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
-  verified                      Sidecar.txt  OK
+  verified                      Sidecar.txt  xxh64: OK
   calculated root hash  xxh64: 8d02114c32e28cbe (content), f557f8ca8e5a88ef (structure)
 Created new generation ascmhl/0002_A002R2EC_2020-01-17_143000.mhl
 
@@ -94,13 +94,13 @@ and create a second generation with additional (new) MD5 hashes.
 
 $ ascmhl.py create -v -h md5 /file_server/A002R2EC
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  created new, verified hash for          Clips/A002C006_141024_R2EC.mov  md5: f5ac8127b3b6b85cdc13f237c6005d80
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
-  created new, verified hash for          Clips/A002C007_141024_R2EC.mov  md5: 614dd0e977becb4c6f7fa99e64549b12
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  created new (verif.) hash for Clips/A002C006_141024_R2EC.mov  md5: f5ac8127b3b6b85cdc13f237c6005d80
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
+  created new (verif.) hash for Clips/A002C007_141024_R2EC.mov  md5: 614dd0e977becb4c6f7fa99e64549b12
   calculated directory hash for Clips  md5: 202a2d71b56b080d9b089c1f4f29a4ba (content), 4a739024fd19d928e9dea6bb5c480200 (structure)
-  verified                      Sidecar.txt  OK
-  created new, verified hash for          Sidecar.txt  md5: 6425c5a180ca0f420dd2b25be4536a91
+  verified                      Sidecar.txt  xxh64: OK
+  created new (verif.) hash for Sidecar.txt  md5: 6425c5a180ca0f420dd2b25be4536a91
   calculated root hash  md5: 6fae2da9bc6dca45486cb91bfea6db70 (content), be1f2eaed208efbed061845a64cacdfa (structure)
 Created new generation ascmhl/0002_A002R2EC_2020-01-17_143000.mhl
 
@@ -140,8 +140,8 @@ An error is shown and create a new generation that documents the failed verifica
 
 $ ascmhl.py create -v /file_server/A002R2EC -h xxh64
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
 ERROR: hash mismatch for        Sidecar.txt  xxh64 (old): 3ab5a4166b9bde44, xxh64 (new): 70d2cf31aaa3eac4
   calculated root hash  xxh64: 8e52e9c3d15e055c (content), 32706d5f4b48f047 (structure)
@@ -200,15 +200,15 @@ of the card sub folders.
 
 $ ascmhl.py create -v /file_server/Reels -h xxh64
 Creating new generation for folder at path: /file_server/Reels ...
-  verified                      A002R2EC/Clips/A002C006_141024_R2EC.mov  OK
-  verified                      A002R2EC/Clips/A002C007_141024_R2EC.mov  OK
+  verified                      A002R2EC/Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      A002R2EC/Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for A002R2EC/Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
-  verified                      A002R2EC/Sidecar.txt  OK
+  verified                      A002R2EC/Sidecar.txt  xxh64: OK
   calculated directory hash for A002R2EC  xxh64: 8d02114c32e28cbe (content), f557f8ca8e5a88ef (structure)
-  verified                      A003R2EC/Clips/A003C011_141024_R2EC.mov  OK
-  verified                      A003R2EC/Clips/A003C012_141024_R2EC.mov  OK
+  verified                      A003R2EC/Clips/A003C011_141024_R2EC.mov  xxh64: OK
+  verified                      A003R2EC/Clips/A003C012_141024_R2EC.mov  xxh64: OK
   calculated directory hash for A003R2EC/Clips  xxh64: f2afc6434255a53d (content), a25d5ca89c95f9e2 (structure)
-  verified                      A003R2EC/Sidecar.txt  OK
+  verified                      A003R2EC/Sidecar.txt  xxh64: OK
   calculated directory hash for A003R2EC  xxh64: 7a82373c131cf40a (content), 1131a950fcc55e4b (structure)
   created original hash for     Summary.txt  xxh64: 0ac48e431d4538ba
   calculated root hash  xxh64: 92950bc8fda076ec (content), 2c2ce52605558158 (structure)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -319,3 +319,12 @@ def test_create_mulitple_hashformats(fs, simple_mhl_history):
 
     assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
     assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output
+
+
+def test_create_mulitple_hashformats_no_dash_n(fs, simple_mhl_history):
+    runner = CliRunner()
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "md5", "-h", "sha1"])
+    assert result.exit_code == 0
+
+    assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
+    assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -328,3 +328,4 @@ def test_create_mulitple_hashformats_no_dash_n(fs, simple_mhl_history):
 
     assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
     assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output
+    

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -310,3 +310,12 @@ def test_creator_info(fs, simple_mhl_history):
     assert "franz@example.com" in result.output
     assert "123-4567" in result.output
     assert "Data Manager" in result.output
+
+
+def test_create_mulitple_hashformats(fs, simple_mhl_history):
+    runner = CliRunner()
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-n", "-h", "md5", "-h", "sha1"])
+    assert result.exit_code == 0
+
+    assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
+    assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -98,13 +98,13 @@ def test_create_directory_hashes(fs):
         file.write("!!")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "xxh64", "-h", "md5"])
     assert "ERROR: hash mismatch for        A/A2.txt" in result.output
     hash_list = MHLHistory.load_from_path("/root").hash_lists[-1]
     # an altered file leads to a different root directory hash
-    assert hash_list.process_info.root_media_hash.hash_entries[0].hash_string == "28ed09733f793dfc"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].hash_string == "28ed09733f793dfc"
     # structure hash stays the same
-    assert hash_list.process_info.root_media_hash.hash_entries[0].structure_hash_string == "89e4debdb80cc068"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].structure_hash_string == "89e4debdb80cc068"
 
     # test that the directory-hash command creates the same root hash
     # FIXME: command doesn't exist any more, replace with tests of verify directory hashes command?
@@ -112,29 +112,44 @@ def test_create_directory_hashes(fs):
     #    assert result.exit_code == 0
     #    assert "root hash: xxh64: adf18c910489663c" in result.output
 
-    assert hash_list.find_media_hash_for_path("B").hash_entries[0].hash_string == "aab0eba57cd1aca9"
-    assert hash_list.find_media_hash_for_path("B").hash_entries[0].structure_hash_string == "fac2a2ceb0fa0c0b"
-    assert hash_list.process_info.root_media_hash.hash_entries[0].hash_string == "28ed09733f793dfc"
-    assert hash_list.process_info.root_media_hash.hash_entries[0].structure_hash_string == "89e4debdb80cc068"
+    assert hash_list.find_media_hash_for_path("B").hash_entries[0].hash_string == "d6df246725efff6ceaee31f663a32cf8"
+    assert hash_list.find_media_hash_for_path("B").hash_entries[1].hash_string == "aab0eba57cd1aca9"
+
+    assert (
+        hash_list.find_media_hash_for_path("B").hash_entries[0].structure_hash_string
+        == "a21e164c1df944733e5e3d4e4ed64f90"
+    )
+    assert hash_list.find_media_hash_for_path("B").hash_entries[1].structure_hash_string == "fac2a2ceb0fa0c0b"
+
+    assert hash_list.process_info.root_media_hash.hash_entries[1].hash_string == "28ed09733f793dfc"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].structure_hash_string == "89e4debdb80cc068"
 
     # rename one file
     os.rename("/root/B/B1.txt", "/root/B/B2.txt")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "xxh64", "-h", "c4"])
     assert "ERROR: hash mismatch for        A/A2.txt" in result.output
     # in addition to the failing verification we also have a missing file B1/B1.txt
     assert "missing file(s):\n  B/B1.txt" in result.output
     hash_list = MHLHistory.load_from_path("/root").hash_lists[-1]
     # the file name is part of the structure directory hash of the containing directory so it's hash changes
-    assert hash_list.find_media_hash_for_path("B").hash_entries[0].structure_hash_string == "7ae620e883160eb3"
+    assert (
+        hash_list.find_media_hash_for_path("B").hash_entries[0].structure_hash_string
+        == "c42qegPDBxh16Vqi4qFGh1EQv39nEbVmZ9R1LGkaVr1dEBRcD69pH3r5vdGDSwceQLEZc872kQho5Cforb95s2wjH8"
+    )
+    assert hash_list.find_media_hash_for_path("B").hash_entries[1].structure_hash_string == "7ae620e883160eb3"
     # .. and the content hash stays the same
-    assert hash_list.find_media_hash_for_path("B").hash_entries[0].hash_string == "aab0eba57cd1aca9"
+    assert (
+        hash_list.find_media_hash_for_path("B").hash_entries[0].hash_string
+        == "c43X1ve8nmicwGit4fnhs428pTCV6ZjXQsorxPLNx3396oRuQFaq79iLR2ZsPoWN8yckFzZdkqZ21igH8K7rWAoDMa"
+    )
+    assert hash_list.find_media_hash_for_path("B").hash_entries[1].hash_string == "aab0eba57cd1aca9"
 
     # a renamed file also leads to a different root structure directory hash
-    assert hash_list.process_info.root_media_hash.hash_entries[0].structure_hash_string == "0bba67923d19d36b"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].structure_hash_string == "0bba67923d19d36b"
     # and an unchanged content hash
-    assert hash_list.process_info.root_media_hash.hash_entries[0].hash_string == "28ed09733f793dfc"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].hash_string == "28ed09733f793dfc"
 
     # test that the directory-hash command creates the same root hash
     # FIXME: command doesn't exist any more, replace with tests of verify directory hashes command?

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -343,3 +343,21 @@ def test_create_mulitple_hashformats_no_dash_n(fs, simple_mhl_history):
 
     assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
     assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output
+
+
+@freeze_time("2020-01-16 09:15:00")
+def test_create_mulitple_hashformats_double_hashformat(fs, simple_mhl_history):
+    runner = CliRunner()
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "c4"])
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "md5", "-h", "sha1"])
+
+    # check if mhl file exists
+    mhlfilepath = "/root/ascmhl/0003_root_2020-01-16_091500.mhl"
+    assert os.path.isfile(mhlfilepath)
+
+    # check if mhl file validates
+    result = runner.invoke(ascmhl.commands.xsd_schema_check, [mhlfilepath])
+    if result.exit_code != 0:
+        print(result.output)
+
+    assert result.exit_code == 0

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -328,4 +328,3 @@ def test_create_mulitple_hashformats_no_dash_n(fs, simple_mhl_history):
 
     assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
     assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output
-    

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -53,14 +53,14 @@ def test_aggregate_hashing_of_data(fs):
     }
 
     # Generate the hash pairings for the file and specified formats
-    hash_pairs = multiple_format_hash_data(data, hash_type_and_value.keys())
+    hash_lookup = multiple_format_hash_data(data, hash_type_and_value.keys())
 
     # Make sure each pair's value matches the known hash value
     evaluated_formats = []
-    for pair in hash_pairs:
-        known_hash = hash_type_and_value[pair.hash_format]
-        evaluated_formats.append(pair.hash_format)
-        assert pair.hash_value == known_hash
+    for hash_format, hash_value in hash_lookup.items():
+        known_hash = hash_type_and_value[hash_format]
+        evaluated_formats.append(hash_format)
+        assert hash_value == known_hash
 
     # Make sure each stored format was represented in the hash pairings
     for k in hash_type_and_value:
@@ -103,14 +103,14 @@ def test_aggregate_hashing_of_file(fs):
     }
 
     # Generate the hash pairings for the file and specified formats
-    hash_pairs = multiple_format_hash_file(file, hash_type_and_value.keys())
+    hash_lookup = multiple_format_hash_file(file, hash_type_and_value.keys())
 
     # Make sure each pair's value matches the known hash value
     evaluated_formats = []
-    for pair in hash_pairs:
-        known_hash = hash_type_and_value[pair.hash_format]
-        evaluated_formats.append(pair.hash_format)
-        assert pair.hash_value == known_hash
+    for hash_format, hash_value in hash_lookup.items():
+        known_hash = hash_type_and_value[hash_format]
+        evaluated_formats.append(hash_format)
+        assert hash_value == known_hash
 
     # Make sure each stored format was represented in the hash pairings
     for k in hash_type_and_value:

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -37,6 +37,42 @@ def test_hash_data():
         assert h == v  # assert our computed hash equals expected hash
 
 
+def test_aggregate_hashing_of_data(fs):
+    # the data to hash
+    data = b"media-hash-list"
+
+    # map of hash algorithm to expected hash value
+    hash_type_and_value = {
+        "md5": "9db0fc9f30f5ee70041a7538809e2858",
+        "sha1": "7b57673ac5633937a55b59009ad0c57ee08188b7",
+        "xxh32": "f67c5a4f",
+        "xxh64": "584b2ea1974f2b7c",
+        "xxh3": "6d4cbd75905c81aa",
+        "xxh128": "61a67c014f703a456ee7a776fd8c06bd",
+        "c4": "c456LycWwpMMS7VDZEKvYv2L1uJS6s4qAFnaJdnQiy5JVbBFZMA8aLDS6SPaJjLqxXH4qZdnbuktopMt9frtC2qL1R",
+    }
+
+    # Get a list of all the hash formats
+    hash_formats = []
+
+    for k in hash_type_and_value:
+        hash_formats.append(k)
+
+    # Generate the hash pairings for the file and specified formats
+    hash_pairs = multiple_format_hash_data(data, hash_formats)
+
+    # Make sure each pair's value matches the known hash value
+    evaluated_formats = []
+    for pair in hash_pairs:
+        known_hash = hash_type_and_value[pair.hash_format]
+        evaluated_formats.append(pair.hash_format)
+        assert pair.hash_value == known_hash
+
+    # Make sure each stored format was represented in the hash pairings
+    for k in hash_type_and_value:
+        assert k in evaluated_formats
+
+
 def test_hash_file(fs):
     # write some data to a file so we can hash it.
     file, data = "/data-file.txt", "media-hash-list"
@@ -55,6 +91,42 @@ def test_hash_file(fs):
     for k, v in hash_type_and_value.items():
         h = hash_file(file, k)
         assert h == v  # assert our computed hash equals expected hash
+
+
+def test_aggregate_hashing_of_file(fs):
+    # write some data to a file so we can hash it.
+    file, data = "/data-file.txt", "media-hash-list"
+    fs.create_file(file, contents=data)
+    # map of hash algorithm to expected hash value
+    hash_type_and_value = {
+        "md5": "9db0fc9f30f5ee70041a7538809e2858",
+        "sha1": "7b57673ac5633937a55b59009ad0c57ee08188b7",
+        "xxh32": "f67c5a4f",
+        "xxh64": "584b2ea1974f2b7c",
+        "xxh3": "6d4cbd75905c81aa",
+        "xxh128": "61a67c014f703a456ee7a776fd8c06bd",
+        "c4": "c456LycWwpMMS7VDZEKvYv2L1uJS6s4qAFnaJdnQiy5JVbBFZMA8aLDS6SPaJjLqxXH4qZdnbuktopMt9frtC2qL1R",
+    }
+
+    # Get a list of all the hash formats
+    hash_formats = []
+
+    for k in hash_type_and_value:
+        hash_formats.append(k)
+
+    # Generate the hash pairings for the file and specified formats
+    hash_pairs = multiple_format_hash_file(file, hash_formats)
+
+    # Make sure each pair's value matches the known hash value
+    evaluated_formats = []
+    for pair in hash_pairs:
+        known_hash = hash_type_and_value[pair.hash_format]
+        evaluated_formats.append(pair.hash_format)
+        assert pair.hash_value == known_hash
+
+    # Make sure each stored format was represented in the hash pairings
+    for k in hash_type_and_value:
+        assert k in evaluated_formats
 
 
 def test_hash_of_hash_list():

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -52,14 +52,8 @@ def test_aggregate_hashing_of_data(fs):
         "c4": "c456LycWwpMMS7VDZEKvYv2L1uJS6s4qAFnaJdnQiy5JVbBFZMA8aLDS6SPaJjLqxXH4qZdnbuktopMt9frtC2qL1R",
     }
 
-    # Get a list of all the hash formats
-    hash_formats = []
-
-    for k in hash_type_and_value:
-        hash_formats.append(k)
-
     # Generate the hash pairings for the file and specified formats
-    hash_pairs = multiple_format_hash_data(data, hash_formats)
+    hash_pairs = multiple_format_hash_data(data, hash_type_and_value.keys())
 
     # Make sure each pair's value matches the known hash value
     evaluated_formats = []
@@ -108,14 +102,8 @@ def test_aggregate_hashing_of_file(fs):
         "c4": "c456LycWwpMMS7VDZEKvYv2L1uJS6s4qAFnaJdnQiy5JVbBFZMA8aLDS6SPaJjLqxXH4qZdnbuktopMt9frtC2qL1R",
     }
 
-    # Get a list of all the hash formats
-    hash_formats = []
-
-    for k in hash_type_and_value:
-        hash_formats.append(k)
-
     # Generate the hash pairings for the file and specified formats
-    hash_pairs = multiple_format_hash_file(file, hash_formats)
+    hash_pairs = multiple_format_hash_file(file, hash_type_and_value.keys())
 
     # Make sure each pair's value matches the known hash value
     evaluated_formats = []


### PR DESCRIPTION
- Switching on "multiple=True" for "-h" option
-  Necessary refactoring and extension of hasher and command methods
- Solves issue #112 