### PR TITLE
Command regrouping to remove verify command from ascmhl tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,26 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 # ASC Media Hash List (ASC MHL)
-> The software in this repository aids the ongoing specification process of the ASC MHL format by the Advanced Data Management Subcommittee of the ASC Motion Imaging Technology Council at the [American Society of Cinematographers](https://theasc.com) (ASC). 
+> The software in this repository is the reference implementation for the ASC Media Hash List (ASC MHL) format 
+> specification by the Advanced Data Management Subcommittee of the ASC Motion Imaging Technology Council (MITC) at 
+> the [American Society of Cinematographers](https://theasc.com) (ASC). 
 >
-> Resources on [theasc.com](https://theasc.com):
-> * 📄 [ASC MHL Specification page](https://theasc.com/asc/asc-media-hash-list) (with committe draft for public review)
-> * 📄 [ASC MHL One-Sheet page](https://theasc.com/reports/asc-mhl-one-sheet)
+> Resources:
+> * 🌎 [ASC MHL Homepage](https://ascmhl.com/) (at [https://ascmhl.com/](https://ascmhl.com/))
+> * 📄 [ASC MHL Specification page](https://theasc.com/asc/asc-media-hash-list) (at [theasc.com](https://theasc.com))
 > 
-> This software is work-in-progress and not intended to be used in production (yet).
-> 
-> In case you are looking for the original specification of MHL, please take a look at [https://mediahashlist.org](https://mediahashlist.org).
+> In case you are looking for the original specification of MHL, please take a look at 
+> [https://mediahashlist.org](https://mediahashlist.org).
 
-Ensuring file integrity when backing up and verifying files during production and post production is of utmost importance. The ASC MHL is used to create a chain of custody by tracking each and every copy made between the media’s initial download on set, all the way through to final archival.
+Ensuring file integrity when backing up and verifying files during production and post-production is of utmost 
+importance. The ASC MHL is used to create a chain of custody by tracking each and every copy made between the 
+media’s initial download on set, all the way through to final archival.
 
-The ASC MHL uses common checksum methods for hashing files and folders, specifies what information is gathered, where the checksum is placed, and documents these hashes together with essential file metadata in an XML format that is human readable.
+The ASC MHL uses common checksum methods for hashing files and folders, specifies what information is gathered, where 
+the checksum is placed, and documents these hashes together with essential file metadata in an XML format that is 
+human-readable.
 
-This repository holds all information about the document format,  a reference implementation, and tools.
+This repository holds all information about the document format, a reference implementation, and tools.
 
 ## ASC MHL Format Specification
 
@@ -32,13 +37,14 @@ The schema definition can be found in the `./xsd` folder.
 
 ## `mhllib` Reference Implementation 
 
-The implementation of a reference library aims to be used in applications and tools dealing with ASC MHL files. The library takes responsibility of dealing with complex use cases of nesting and assembling of information.
+The implementation of a reference library aims to be used in applications and tools dealing with ASC MHL files. The 
+library takes responsibility of dealing with complex use cases of nesting and assembling of information.
 
 The reference library covers
 
 * reading ascmhl folders and their contents
 * parsing and writing of ASC MHL XML files
-* parsing and writing ASC MHL chain files
+* parsing and writing ASC MHL chain and collection files
 * dealing with nested mhl folders
 
 ASC MHL supports the hash formats
@@ -52,30 +58,34 @@ The source code for `mhllib` can be found in the `./ascmhl` folder.
 
 ## The `ascmhl` Tool
 
-The `ascmhl` tool is a command line tool based on `mhllib` that allows to perform typical activities for the use cases of ASC MHL.
+The `ascmhl` tool is a command line tool based on `mhllib` that allows to perform typical activities for the use 
+cases of ASC MHL.
 
-The ASC MHL tool implementation can
+* [The `create`command](#createcommand): Create a new generation for a folder or file(s)
+* [The `diff`command](#diffcommand): Diff an entire folder structure
+* [The `flatten`command](#flattencommand): Flatten an MHL history into one external manifest
+* [The `info`command](#infocommand): Prints information from the ASC MHL history
 
-* create and extend ASC MHL history for given files and entire file hierarchies in a file system,
-* output information about recorded history (summary of history or detailed information about single files), and
-* verify files and entire file hierarchies.
-
-Typical scenarios, sample CLI output, and generated ASC MHL files can be found in the [README.md](https://github.com/ascmitc/mhl/blob/master/examples/scenarios/) file in the ``examples/scenarios`` folder of the git repository.
+Typical scenarios, sample CLI output, and generated ASC MHL files can be found in the 
+[README.md](https://github.com/ascmitc/mhl/blob/master/examples/scenarios/) file in the ``examples/scenarios`` folder 
+of the git repository.
 
 The documentation can also be found at [https://ascmhl.readthedocs.io/](https://ascmhl.readthedocs.io/)
 
-Jump directly to the commands:
+## The `ascmhl-debug` Tool
 
-* [The `create`command](#createcommand)
-* [The `flatten`command](#flattencommand)
-* [The `verify`command](#verifycommand)
-* [The `diff`command](#diffcommand)
-* [The `info`command](#infocommand)
+The `ascmhl-debug` tool is a command line tool with additional operations and commands that might come in handy during
+ implementation or testing.
 
+* [The `verify`command](#verifycommand): Verify a folder, single file(s), or a directory hash (without writing a 
+new generation)
+* [The `xsd-schema-check`command](#xsdschemacheckcommand): Checks a .mhl file against the xsd schema definition
+* [The `hash`command](#hashcommand): Create and print a hash value for a file
 
 ## Getting started
 
-The `mhllib` as well as the `ascmhl` tool require a few dependencies that need to be installed first. 
+The `mhllib` as well as the `ascmhl` and `ascmhl-degug` tools require a few dependencies that need to be installed 
+first. 
 
 For installing system dependencies on macOS [Homebrew](https://brew.sh) is recommended.
 
@@ -111,18 +121,19 @@ $ source env/bin/activate
 $ pip3 install --editable .
 ```
 
-This will install a wrapper script for `ascmhl` to be available on your `$PATH`. Inside the virtualenv, this wrapper 
-will be installed as `env/bin/ascmhl`. Regular users might have it in 
+This will install the wrapper scripts `ascmhl` and `ascmhl-debug` to be available on your `$PATH`. Inside the 
+virtualenv, this wrapper will be installed as `env/bin/ascmhl`. Regular users might have it in 
 `/Library/Frameworks/Python.framework/Versions/3.9/bin/ascmhl` or `/usr/local/bin`. For Windows users, pip will 
-create an `ascmhl.exe`.
+create an `ascmhl.exe` and an `ascmhl-debug.exe`.
 
 More information on installing Python commandline tools using `entry_points` can be found here:
 * https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
 * https://packaging.python.org/specifications/entry-points/#use-for-scripts
 * https://click.palletsprojects.com/en/master/setuptools/
 
-Adding the `-e / --editable` flag installs a linked version to your `site-packages` directory to allow editing the source 
-files in your working directory as usual.
+Adding the `-e / --editable` flag installs a linked version to your `site-packages` directory to allow editing the 
+source files in your working directory as usual.
+
 
 ## Common Scenarios for `ascmhl`
 
@@ -139,48 +150,68 @@ Additional utility commands:
 
 ### Working with file hierarchies (with completeness check)
 
-The most common commands when using the `ascmhl` in data management scenarios are the `create` and the `check` commands in their default behavior (without subcommand options). 
+The most common commands when using the `ascmhl` in data management scenarios are the `create` and the `check` 
+commands in their default behavior (without subcommand options). 
 
-Creating a new generation for a folder / drive with the `create` command traverses through a folder hierarchy, hashes all found files and compares the hashes against the records in the `ascmhl` folder (if present). The command creates a new generation (or an initial one) for the content of an entire folder at the given folder level. It can be used to document all files in a folder or drive with all verified or newly created file hashes of the moment the `create` command ran.
+Creating a new generation for a folder / drive with the `create` command traverses through a folder hierarchy, hashes 
+all found files and compares the hashes against the records in the `ascmhl` folder (if present). The command creates 
+a new generation (or an initial one) for the content of an entire folder at the given folder level. It can be used to 
+document all files in a folder or drive with all verified or newly created file hashes of the moment the `create` 
+command ran.
 
-Checking a folder / drive with the `verify` command traverses through the content of a folder, hashes all found files and compares the hashes against the records in the `ascmhl` folder. The `verify` command behaves like a `create` command (both without additional options), but doesn't write new generations. It can be used to verify the content of a received drive with existing ascmhl information.
+Checking a folder / drive with the `verify` command traverses through the content of a folder, hashes all found files 
+and compares the hashes against the records in the `ascmhl` folder. The `verify` command behaves like a `create` 
+command (both without additional options), but doesn't write new generations. It can be used to verify the content of 
+a received drive with existing ascmhl information.
 
-The `diff` command also traverses through the content of a folder / drive.  The `diff` command thus behaves like the `verify` command, but the `diff` command does not hash any files (e.g. doesn't do file verification) and thus is much faster in execution. It can be used to print all files that are existent in the file system and are not registered in the `ascmhl` folder yet, and all files that are registered in the `ascmhl` folder but that are missing in the file system.
+The `diff` command also traverses through the content of a folder / drive.  The `diff` command thus behaves like the 
+`verify` command, but the `diff` command does not hash any files (e.g. doesn't do file verification) and thus is much 
+faster in execution. It can be used to print all files that are existent in the file system and are not registered in 
+the `ascmhl` folder yet, and all files that are registered in the `ascmhl` folder but that are missing in the file 
+system.
 
 
 ### Working with single files (without completeness check)
 
-In some scenarios working with an entire folder structure is not adequate, and finer control of the processes files is needed. For those scenarios the `create` and `verify` commands are used with additional subcommand options.
+In some scenarios working with an entire folder structure is not adequate, and finer control of the processes files 
+is needed. For those scenarios the `create` and `verify` commands are used with additional subcommand options.
 
-Adding single files in a new generation with the `create -sf` ("single files, no completeness check") command allows to add single files to an existing folder structure and create new generations only with records of these files.
+Adding single files in a new generation with the `create -sf` ("single files, no completeness check") command allows 
+to add single files to an existing folder structure and create new generations only with records of these files.
 
-Hashing and verifying single files against hash information stored in the `ascmhl` folder with the `verify -sf` ("single files") command allows to "check" single files without the need for a (probably much longer running) check of the integrity of the entire folder structure. 
+Hashing and verifying single files against hash information stored in the `ascmhl` folder with the `verify -sf` 
+("single files") command allows to "check" single files without the need for a (probably much longer running) check 
+of the integrity of the entire folder structure. 
 
 The `info -sf` ("single file") command prints the known history of a single file with details about all generations.
 
 
 ## Commands of `ascmhl`
 
-_Implementation status 2020-09-08:_
+_Implementation status 2022-03-14:_
 
-* __Implemented__: `create`, `flatten` (partially), `verify`, `diff`, `info` (partially), `xsd-schema-check`
-* __Not implemented yet__: some subcommands for `flatten`, `verify`, `info`
-
-_The commands are also marked below with their current implementation status._
+* __Implemented__: `create`, `flatten` (partially), `diff`, `info` (partially)
 
 
 <a name="createcommand"></a>
 ### The `create` command
 
-The `create` command hashes all files given with the different options and creates a new generation in the mhl-history with records for all hashed files. The command compares the hashes against the hashes stored in previous generations if available.
+The `create` command hashes all files given with the different options and creates a new generation in the mhl-history 
+with records for all hashed files. The command compares the hashes against the hashes stored in previous generations 
+if available.
 
 #### `create` default behavior (for file hierarchy, with completeness check)
 
-The `create` command traverses through a folder hierarchy (such as a folder with media files, a camera card, or an entire drive). The command hashes all files (not ignored by the given ignore patterns given with the `-i` or `-ii` options) and the hashes are compared against records in the `ascmhl` folder. It records all hashed files in the new generation. Directory hashes are computed and also recorded in the new generation.
+The `create` command traverses through a folder hierarchy (such as a folder with media files, a camera card, or an 
+entire drive). The command hashes all files (not ignored by the given ignore patterns given with the `-i` or `-ii` 
+options) and the hashes are compared against records in the `ascmhl` folder. It records all hashed files in the new 
+generation. Directory hashes are computed and also recorded in the new generation.
 
-The command detects, prints error, and exits with a non-0 exit code if it finds files that are registered in the `ascmhl` folder but that are missing in the file system. 
+The command detects, prints error, and exits with a non-0 exit code if it finds files that are registered in the 
+`ascmhl` folder but that are missing in the file system. 
 
-Files that are existent in the file system but are not registered in the `ascmhl` folder yet, are registered as new entries in the newly created generation(s).
+Files that are existent in the file system but are not registered in the `ascmhl` folder yet, are registered as new 
+entries in the newly created generation(s).
 
 The `create` command takes the root path of the file hierarchy as the parameter:
 
@@ -192,13 +223,18 @@ Creator-info options:
 * `--location`: Location value of the `<creatorinfo>`element.
 * `--comment`: Comment value of the `<creatorinfo>`element.
 * `--author_name`: Name value of the `<author>` element in the `<creatorinfo>`element.
-* `--author_email`: Email value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be set for this option).
-* `--author_phone`: Phone value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be set for this option).
-* `--author_role`: Role value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be set for this option).
+* `--author_email`: Email value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be 
+set for this option).
+* `--author_phone`: Phone value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be 
+set for this option).
+* `--author_role`: Role value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be 
+set for this option).
 
-It works on folders with or without an `ascmhl` folder within the given folder hierarchy, and creates a new `ascmhl` folder at the given folder level if none is present before.
+It works on folders with or without an `ascmhl` folder within the given folder hierarchy, and creates a new `ascmhl` 
+folder at the given folder level if none is present before.
 
-`ascmhl` folders further down the file hierarchy are read, handled, and referenced in top-level `ascmhl` folders. Existing `ascmhl` folders further down the folder structure will also get a new generation added.
+`ascmhl` folders further down the file hierarchy are read, handled, and referenced in top-level `ascmhl` folders. 
+Existing `ascmhl` folders further down the folder structure will also get a new generation added.
 
 Implementation:
 
@@ -218,7 +254,8 @@ create new generation(s) (mhllib)
 
 #### `create` with `-sf` option(s) (for single file(s), no completeness check)
 
-The `create` command with `-sf` option is run with the root path of the file hierarchy as well as one or multiple paths to the individual files to be recorded as the parameters.
+The `create` command with `-sf` option is run with the root path of the file hierarchy as well as one or multiple 
+paths to the individual files to be recorded as the parameters.
 
 This command can be used for instance when adding single files to an already mhl-managed file hierarchy.
 
@@ -226,7 +263,8 @@ This command can be used for instance when adding single files to an already mhl
 $ ascmhl create /path/to/root/folder -sf /path/to/single/file1 [-sf /path/to/single/file2 ..]
 ```
 
-A new generation is created in all `ascmhl` folders below the given root path (e.g. in a nested mhl-history). If no mhl-history is present yet, an error is thrown.
+A new generation is created in all `ascmhl` folders below the given root path (e.g. in a nested mhl-history). If no 
+mhl-history is present yet, an error is thrown.
 
 No other files than the ones specified as `-sf` options are handled by this command.
 
@@ -244,7 +282,8 @@ for each file from input
 <a name="flattencommand"></a>
 ### The `flatten` command 
 
-The `flatten` command takes the root path of the file hierarchy and the destination path for the flattened manifest as the parameter:
+The `flatten` command takes the root path of the file hierarchy and the destination path for the flattened manifest as 
+the parameter:
 
 ```
 $ ascmhl flatten [-i ignore pattern|-ii /path/to/ignore-file.txt] [creator-info options] /path/to/folder/ /destination/path/
@@ -254,9 +293,12 @@ Creator-info options:
 * `--location`: Location value of the `<creatorinfo>`element.
 * `--comment`: Comment value of the `<creatorinfo>`element.
 * `--author_name`: Name value of the `<author>` element in the `<creatorinfo>`element.
-* `--author_email`: Email value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be set for this option).
-* `--author_phone`: Phone value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be set for this option).
-* `--author_role`: Role value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be set for this option).
+* `--author_email`: Email value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be 
+set for this option).
+* `--author_phone`: Phone value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be 
+set for this option).
+* `--author_role`: Role value of the `<author>` element in the `<creatorinfo>`element (`--author_name` must also be 
+set for this option).
 
 _TBD_
 
@@ -293,12 +335,102 @@ Options:
 
 ```
 
+
+
+
+<a name="infocommand"></a>
+### The `info` command 
+
+#### `info` default behavior
+
+The `ascmhl` folder contains well readable XML files, but the number of recorded files, generations, hash entries, 
+verification info and so forth adds up to an amount of information that cannot be quickly understood. The `info` 
+command helps to get a quick overview of the contents of the stored information in an `ascmhl` folder. 
+
+The `info` command prints
+* a list of generations (with the `-v` option also with creator info and process info)
+* _[not implemented yet]_ a summary (with the `-s` subcommand option) of the information in an ascmhl folder, such as 
+* number of recorded files, and a list of the generations with their creator info, and/or
+* _[not implemented yet]_ a list (with the `-l` option) of all file (and folder) records stored in an ascmhl folder, 
+* together with relative file paths, file size, and known file hashes.
+
+It is run with the path to a specific `ascmhl` folder as the parameter.
+
+```
+$ ascmhl info [-s|-l] [-v] /path/to/ascmhl/ 
+```
+
+Implementation:
+
+```
+error if no mhl folder found on root level
+read (recursive) mhl history (mhllib)
+if summary option:
+	print summary
+if list option:
+	for each file record
+		print file info, hashes, etc.
+```
+
+
+#### `info` with the `-sf` subcommand option 
+
+The `info` command with the `-sf` subcommand option outputs information about the full and detailed history 
+information about one file.
+
+```
+$ ascmhl info -sf /path/to/file [-sf /path/to/other/file] [/root/path]
+```
+
+The command outputs each generation where the file has been handled, including date, hash, and activity (and creator 
+info and absolute path with the `-v` option). The history information is read from the "next" ASC MHL history found in 
+the path, of at the given root path.
+
+Implementation:
+
+```
+find mhl-history information in the path above (mhllib)
+	error of no `ascmhl` folder is found
+print detailed info for file
+```
+
+
+#### `info` with the `-dh` subcommand option _[not implemented yet]_
+
+The `info` command with the `-dh` subcommand option prints
+* the directory hash of a folder computed from stored file hashes of an `ascmhl` folder (with the `-dh` option).
+
+The directory hash can be used to quickly verify if the state of a folder structure is still the same compared to the 
+last generation created with a `create` command (manually compare with the hash in the `<root>` tag in the ASC MHL 
+file).
+
+It is run with the path to a specific `ascmhl`folder and the path to the desired folder for the computed directory 
+hash.
+
+```
+$ ascmhl info -dh /path/to/ascmhl/ /path/to/sub/folder 
+```
+
+Implementation:
+
+```
+error if no mhl folder found on root level
+read (recursive) mhl history (mhllib)
+calculate directory hash from file hashes
+print directory hash
+```
+
+
+
+## Commands of `ascmhl-debug`
+
 <a name="verifycommand"></a>
 ### The `verify` command
 
 #### `verify` default behavior (for file hierarchy, with completeness check)
 
-The `verify` command traverses through the content of a folder, hashes all found files  (filtered by the ignore patterns from the `ascmhl` folder) and compares the hashes against the records in the `ascmhl` folder.
+The `verify` command traverses through the content of a folder, hashes all found files  (filtered by the ignore 
+patterns from the `ascmhl` folder) and compares the hashes against the records in the `ascmhl` folder.
 
 The command detects, prints errors, and exits with a non-0 exit code for
 
@@ -346,7 +478,8 @@ $ ascmhl verify -sf /absolute/path/to/single/file
 $ ascmhl verify -sf realtive/path/to/single/file
 ```
 
-The command looks for an `ascmhl` folder in the folders above the given files. If no mhl-history is present yet, an error is thrown.
+The command looks for an `ascmhl` folder in the folders above the given files. If no mhl-history is present yet, an 
+error is thrown.
 
 Implementation:
 
@@ -367,15 +500,20 @@ on error (including mismatching hashes):
 
 #### `verify` with `-dh` subcommand option (for directory hash)
 
-The `verify` command with the `-dh` subcommand (or `--directory_hash`) option creates the directory hash by hashing the contained files of the given directory path (filtered by the ignore patterns from the `ascmhl` folder) and compares it with the to-be-expected directory hash calculated from the file hashes (same calculation as the `info` command with the `-dh` subcommand option).
+The `verify` command with the `-dh` subcommand (or `--directory_hash`) option creates the directory hash by hashing 
+the contained files of the given directory path (filtered by the ignore patterns from the `ascmhl` folder) and compares
+it with the to-be-expected directory hash calculated from the file hashes (same calculation as the `info` command with 
+the `-dh` subcommand option).
 
 
 ```
 $ ascmhl verify -dh [-co [-ro]] /path/to/folder
 ```
 
-The `-co` option (or `--calculate_only`) only calculates and prints the directory hashes and doesn't verify them against an existing history. 
-This option also works when no history is present. The `-ro` option (or `--root_only`) only calculates and prints the root directory hash. This option is only in effect with the `-co` option.
+The `-co` option (or `--calculate_only`) only calculates and prints the directory hashes and doesn't verify them 
+against an existing history. 
+This option also works when no history is present. The `-ro` option (or `--root_only`) only calculates and prints the 
+root directory hash. This option is only in effect with the `-co` option.
 
 
 Implementation:
@@ -397,7 +535,8 @@ on error (including mismatching hash):
 
 #### `verify` with `-pl` subcommand option (for packing lists)
 
-The `verify` command with the `-pl` subcommand (or `--packing_list`) option can be used to verify a folder structure with a given packing list. 
+The `verify` command with the `-pl` subcommand (or `--packing_list`) option can be used to verify a folder structure 
+with a given packing list. 
 
 It is run with the path to the packing list manifest file as the parameter.
 
@@ -412,7 +551,9 @@ _TBD_
 <a name="diffcommand"></a>
 ### The `diff` command
 
-The `diff` command is very similar to the `verify` command in the default behavior, only that it doesn't create hashes and doesn't verify them. It can be used to quickly check if a folder structure has new files that have not been recorded yet, or if files are missing.
+The `diff` command is very similar to the `verify` command in the default behavior, only that it doesn't create hashes 
+and doesn't verify them. It can be used to quickly check if a folder structure has new files that have not been 
+recorded yet, or if files are missing.
 
 The command detects, prints errors, and exits with a non-0 exit code for
 
@@ -445,84 +586,14 @@ end with exit !=0 if at least one of the files has failed, a file was \
 ```
 
 
-<a name="infocommand"></a>
-### The `info` command 
-
-#### `info` default behavior
-
-The `ascmhl` folder contains well readable XML files, but the number of recorded files, generations, hash entries, verification info and so forth adds up to an amount of information that cannot be quickly understood. The `info` command helps to get a quick overview of the contents of the stored information in an `ascmhl` folder. 
-
-The `info` command prints
-* a list of generations (with the `-v` option also with creator info and process info)
-* _[not implemented yet]_ a summary (with the `-s` subcommand option) of the information in an ascmhl folder, such as number of recorded files, and a list of the generations with their creator info, and/or
-* _[not implemented yet]_ a list (with the `-l` option) of all file (and folder) records stored in an ascmhl folder, together with relative file paths, file size, and known file hashes.
-
-It is run with the path to a specific `ascmhl` folder as the parameter.
-
-```
-$ ascmhl info [-s|-l] [-v] /path/to/ascmhl/ 
-```
-
-Implementation:
-
-```
-error if no mhl folder found on root level
-read (recursive) mhl history (mhllib)
-if summary option:
-	print summary
-if list option:
-	for each file record
-		print file info, hashes, etc.
-```
-
-
-#### `info` with the `-sf` subcommand option 
-
-The `info` command with the `-sf` subcommand option outputs information about the full and detailed history information about one file.
-
-```
-$ ascmhl info -sf /path/to/file [-sf /path/to/other/file] [/root/path]
-```
-
-The command outputs each generation where the file has been handled, including date, hash, and activity (and creator info and absolute path with the `-v` option). The history information is read from the "next" ASC MHL history found in the path, of at the given root path.
-
-Implementation:
-
-```
-find mhl-history information in the path above (mhllib)
-	error of no `ascmhl` folder is found
-print detailed info for file
-```
-
-
-#### `info` with the `-dh` subcommand option _[not implemented yet]_
-
-The `info` command with the `-dh` subcommand option prints
-* the directory hash of a folder computed from stored file hashes of an `ascmhl` folder (with the `-dh` option).
-
-The directory hash can be used to quickly verify if the state of a folder structure is still the same compared to the last generation created with a `create` command (manually compare with the hash in the `<root>` tag in the ASC MHL file).
-
-It is run with the path to a specific `ascmhl`folder and the path to the desired folder for the computed directory hash.
-
-```
-$ ascmhl info -dh /path/to/ascmhl/ /path/to/sub/folder 
-```
-
-Implementation:
-
-```
-error if no mhl folder found on root level
-read (recursive) mhl history (mhllib)
-calculate directory hash from file hashes
-print directory hash
-```
-
-
 ### The `xsd-schema-check` command
 
-The `xsd-schema-check` command validates a given ASC MHL Manifest file against the XML XSD. This command can be used to ensure the creation of syntactically valid ASC MHL files, for example during  implementation of tools creating ASC MHL files.
+The `xsd-schema-check` command validates a given ASC MHL Manifest file against the XML XSD. This command can be used 
+to ensure the creation of syntactically valid ASC MHL files, for example during  implementation of tools creating 
+ASC MHL files.
 
-_Note: The `xsd-schema-check` command must be run from a directory with a `xsd` subfolder where the ASC MHL xsd files are located (for example it can be run from the root folder of the ASC MHL git repository)._
+_Note: The `xsd-schema-check` command must be run from a directory with a `xsd` subfolder where the ASC MHL xsd files 
+are located (for example it can be run from the root folder of the ASC MHL git repository)._
 
 ```
 $ ascmhl xsd-schema-check /path/to/ascmhl/XXXXX.mhl
@@ -530,7 +601,8 @@ $ ascmhl xsd-schema-check /path/to/ascmhl/XXXXX.mhl
 
 #### `xsd-schema-check` with the `-df` subcommand option
 
-The `xsd-schema-check` command with the `-df` subcommand option can validates a ASC MHL Directory file instead of a manifest file.
+The `xsd-schema-check` command with the `-df` subcommand option can validates a ASC MHL Directory file instead of a 
+manifest file.
 
 It is run with the path to a ASC MHL Directory file.
 
@@ -541,12 +613,13 @@ $ ascmhl xsd-schema-check -df /path/to/ascmhl/ascmhl_chain.xml
 
 ## Known issues
 
-The current state of the implementation is intended to give a good overview what can be done with ASC MHL. Nonetheless this is not yet a complete implementation of the ASC MHL specification:
+The current state of the implementation is intended to give a good overview what can be done with ASC MHL. Nonetheless 
+this is not yet a complete implementation of the ASC MHL specification:
 
 * Currently not all initially specified commands are implemented yet (see sections above)
-* Renaming of files is currently not implemented (neither as command, nor proper handling in histories and packing lists)
+* Renaming of files is currently not implemented (neither as command, nor proper handling in histories and packing 
+* lists)
 * The chain file is currently not verified yet
-* Some secondary features of the ASC MHL specification are not implemented yet.
 
 _Also see the [GitHub issues](https://github.com/ascmitc/mhl/issues) page for more._
 

--- a/ascmhl/cli/ascmhl_debug.py
+++ b/ascmhl/cli/ascmhl_debug.py
@@ -23,11 +23,11 @@ class NaturalOrderGroup(click.Group):
 
 @click.group(cls=NaturalOrderGroup)
 @click.version_option()
-def mhltool_cli():
+def mhldebugtool_cli():
     pass
 
 
-@mhltool_cli.resultcallback()
+@mhldebugtool_cli.resultcallback()
 def update(*args, **kwargs):
     updater.join(timeout=1)
     if updater.needs_update:
@@ -35,11 +35,10 @@ def update(*args, **kwargs):
 
 
 # new
-mhltool_cli.add_command(commands.create)
-mhltool_cli.add_command(commands.diff)
-mhltool_cli.add_command(commands.flatten)
-mhltool_cli.add_command(commands.info)
+mhldebugtool_cli.add_command(commands.verify)
+mhldebugtool_cli.add_command(commands.xsd_schema_check)
+mhldebugtool_cli.add_command(commands.hash)
 
 
 if __name__ == "__main__":
-    mhltool_cli()
+    mhldebugtool_cli()

--- a/ascmhl/cli/ascmhl_dev.py
+++ b/ascmhl/cli/ascmhl_dev.py
@@ -15,15 +15,15 @@ from ascmhl import _debug_commands
 
 
 @click.group()
-def debug_cli():
+def mhldevtool_cli():
     pass
 
 
-debug_cli.add_command(_debug_commands.readmhlfile)
-debug_cli.add_command(_debug_commands.readchainfile)
-debug_cli.add_command(_debug_commands.readmhlhistory)
-debug_cli.add_command(_debug_commands.create_dummy_file_structure, "create_dummy_file_structure")
+mhldevtool_cli.add_command(_debug_commands.readmhlfile)
+mhldevtool_cli.add_command(_debug_commands.readchainfile)
+mhldevtool_cli.add_command(_debug_commands.readmhlhistory)
+mhldevtool_cli.add_command(_debug_commands.create_dummy_file_structure, "create_dummy_file_structure")
 
 
 if __name__ == "__main__":
-    debug_cli()
+    mhldevtool_cli()

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -1384,28 +1384,75 @@ def seal_file_path(existing_history, file_path, hash_formats: [str], session) ->
     existing_child_history, existing_history_relative_path = existing_history.find_history_for_path(relative_path)
     existing_hash_formats = existing_child_history.find_existing_hash_formats_for_path(existing_history_relative_path)
 
-    current_hash_lookup = multiple_format_hash_file(file_path, hash_formats)
+    hash_formats_to_generate = hash_formats.copy()
+    newly_added_hash_formats = hash_formats.copy()
+
+    # if there are existing entries for this path, the recorded formats must also be generated even if they were not
+    # explicitly specified
+    if existing_hash_formats and len(existing_hash_formats) > 0:
+        newly_added_hash_formats = list(set(hash_formats_to_generate) - set(existing_hash_formats))
+
+        for hash_format in existing_hash_formats:
+            if hash_format not in hash_formats_to_generate:
+                hash_formats_to_generate.append(hash_format)
+
+    # generate the file hashes
+    current_hash_lookup = multiple_format_hash_file(file_path, hash_formats_to_generate)
+
     # in case there is no hash in the required format to use yet, we need to verify also against
     # one of the existing hash formats, we for simplicity use always the first hash format in this example
     # but one could also use a different one if desired
     hash_result_lookup = {}
-    for hash_format in hash_formats:
+
+    # each generated hash value must be added to the session.
+    # however, only the hash formats requested should be included in the returned hash lookup
+    for hash_format in hash_formats_to_generate:
         success = True
-        if len(existing_hash_formats) > 0 and hash_format not in existing_hash_formats:
-            existing_hash_format = existing_hash_formats[0]
-            hash_in_existing_format = hash_file(file_path, existing_hash_format)
-            # FIXME: test what happens if the existing hash verification fails in other format fails
-            # should we then really create two entries
-            success &= session.append_file_hash(
-                file_path, file_size, file_modification_date, existing_hash_format, hash_in_existing_format
-            )
-        current_format_hash = current_hash_lookup[hash_format]
-        # in case the existing hash verification failed we don't want to add the current format hash to the generation
-        # but we need to return it for directory hash creation
-        if success:
-            success &= session.append_file_hash(
-                file_path, file_size, file_modification_date, hash_format, current_format_hash
-            )
-        hash_result_lookup[hash_format] = SealPathResult(current_format_hash, success)
+        success &= session.append_file_hash(
+            file_path, file_size, file_modification_date, hash_format, current_hash_lookup[hash_format]
+        )
+
+        # If the existing hash was requested by the caller it needs to be added to the lookup
+        if hash_format in hash_formats:
+            hash_result_lookup[hash_format] = SealPathResult(current_hash_lookup[hash_format], success)
+
+    #if existing_hash_formats:
+    #    for hash_format in existing_hash_formats:
+    #        success = True
+    #        success &= session.append_file_hash(
+    #            file_path, file_size, file_modification_date, hash_format, current_hash_lookup[hash_format]
+    #        )
+    #
+    #        # If the existing hash was requested by the caller it needs to be added to the lookup
+    #        if hash_format in hash_formats:
+    #            hash_result_lookup[hash_format] = SealPathResult(current_hash_lookup[hash_format], success)
+    #if newly_added_hash_formats:
+    #    for hash_format in newly_added_hash_formats:
+    #        success = True
+    #        success &= session.append_file_hash(
+    #            file_path, file_size, file_modification_date, hash_format, current_hash_lookup[hash_format]
+    #        )
+    #        hash_result_lookup[hash_format] = SealPathResult(current_hash_lookup[hash_format], success)
+
+    #for hash_format in hash_formats:
+    #    success = True
+    #
+    #    #  If previous hashes were made and this format WAS NOT a part of the previous calculation
+    #    if len(existing_hash_formats) > 0 and hash_format not in existing_hash_formats:
+    #        existing_hash_format = existing_hash_formats[0]
+    #        hash_in_existing_format = hash_file(file_path, existing_hash_format)
+    #        # FIXME: test what happens if the existing hash verification fails in other format fails
+    #        # should we then really create two entries
+    #        success &= session.append_file_hash(
+    #            file_path, file_size, file_modification_date, existing_hash_format, hash_in_existing_format
+    #        )
+    #    current_format_hash = current_hash_lookup[hash_format]
+    #    # in case the existing hash verification failed we don't want to add the current format hash to the generation
+    #    # but we need to return it for directory hash creation
+    #    if success:
+    #        success &= session.append_file_hash(
+    #            file_path, file_size, file_modification_date, hash_format, current_format_hash
+    #        )
+    #    hash_result_lookup[hash_format] = SealPathResult(current_format_hash, success)
 
     return hash_result_lookup

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -560,8 +560,9 @@ def verify_entire_folder(
     if exception:
         raise exception
 
+
 def verify_directory_hash_subcommand(
-        root_path, verbose, hash_format, ignore_list=None, ignore_spec_file=None, calculate_only=False, root_only=False
+    root_path, verbose, hash_format, ignore_list=None, ignore_spec_file=None, calculate_only=False, root_only=False
 ):
     """
     Checks MHL directory hashes from all generations against computed directory hashes.
@@ -692,8 +693,8 @@ def verify_directory_hash_subcommand(
                         if not found_hash_format:
                             logger.error(
                                 f"ERROR: verification of folder {relative_path}: No directory hash of type"
-                             f" {hash_format} found"
-                             )
+                                f" {hash_format} found"
+                            )
                             num_failed_verifications += 1
                             add_detected_failure_for_format(directory_hash_entry.hash_format)
             else:
@@ -727,8 +728,9 @@ def verify_directory_hash_subcommand(
         if root_only and relative_path != ".":
             logger.verbose_logging = verbose
 
-        session.append_multiple_format_directory_hashes(folder_path, modification_date, dir_content_hash_lookup,
-                                                        dir_structure_hash_lookup)
+        session.append_multiple_format_directory_hashes(
+            folder_path, modification_date, dir_content_hash_lookup, dir_structure_hash_lookup
+        )
         logger.verbose_logging = verbose
 
         # compare root hashes, works differently
@@ -757,8 +759,8 @@ def verify_directory_hash_subcommand(
                         if not calculate_only:
                             if not found_hash_format:
                                 logger.error(
-                                    f"ERROR: verification of root folder: No directory hash of type {hash_format} "
-                                    f"found")
+                                    f"ERROR: verification of root folder: No directory hash of type {hash_format} found"
+                                )
     exception = None
 
     # check the failure lookup.  if even one format verified, consider the entire process verified
@@ -832,7 +834,7 @@ def _compare_and_log_directory_hashes(
 @click.command()
 @click.argument("file_path", type=click.Path(exists=True))
 @click.option(
-# FIXME: Update to permit multiple hash formats
+    # FIXME: Update to permit multiple hash formats
     "--hash_format",
     "-h",
     type=click.Choice(ascmhl_supported_hashformats),

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -43,6 +43,7 @@ from .traverse import post_order_lexicographic
     is_flag=True,
     help="Verbose output",
 )
+# FIXME: refactor to allow for multiple hash formats
 @click.option(
     "--hash_format",
     "-h",
@@ -220,6 +221,7 @@ def create_for_folder_subcommand(
         # generate directory hashes
         dir_hash_context = None
         if not no_directory_hashes:
+            # FIXME: refactor to allow for multiple hash formats
             dir_hash_context = DirectoryHashContext(hash_format)
         for item_name, is_dir in children:
             file_path = os.path.join(folder_path, item_name)
@@ -232,6 +234,7 @@ def create_for_folder_subcommand(
                         file_path, dir_content_hash_mappings.pop(file_path), dir_structure_hash_mappings.pop(file_path)
                     )
             else:
+                # FIXME: refactor to allow for multiple hash formats
                 hash_string, success = seal_file_path(existing_history, file_path, hash_format, session)
                 if not success:
                     num_failed_verifications += 1
@@ -245,6 +248,7 @@ def create_for_folder_subcommand(
             dir_content_hash_mappings[folder_path] = dir_content_hash
             dir_structure_hash_mappings[folder_path] = dir_structure_hash
         modification_date = datetime.datetime.fromtimestamp(os.path.getmtime(folder_path))
+        # FIXME: refactor to allow for multiple hash formats
         session.append_directory_hashes(
             folder_path, modification_date, hash_format, dir_content_hash, dir_structure_hash
         )
@@ -311,10 +315,12 @@ def create_for_single_files_subcommand(
                     file_path = os.path.join(folder_path, item_name)
                     if is_dir:
                         continue
+                    # FIXME: refactor to allow for multiple hash formats
                     _, success = seal_file_path(existing_history, file_path, hash_format, session)
                     if not success:
                         num_failed_verifications += 1
         else:
+            # FIXME: refactor to allow for multiple hash formats
             _, success = seal_file_path(existing_history, path, hash_format, session)
             if not success:
                 num_failed_verifications += 1
@@ -549,6 +555,7 @@ def verify_directory_hash_subcommand(
 
     # choose the hash format of the latest root directory hash
     if hash_format is None:
+        # FIXME: refactor to allow for multiple hash formats
         generation = -1
         for hash_list in existing_history.hash_lists:
             if hash_list.generation_number > generation:
@@ -573,6 +580,7 @@ def verify_directory_hash_subcommand(
     for folder_path, children in post_order_lexicographic(root_path, ignore_spec.get_path_spec()):
         # generate directory hashes
         dir_hash_context = None
+        # FIXME: refactor to allow for multiple hash formats
         dir_hash_context = DirectoryHashContext(hash_format)
         for item_name, is_dir in children:
             file_path = os.path.join(folder_path, item_name)
@@ -589,6 +597,7 @@ def verify_directory_hash_subcommand(
 
                 num_successful_verifications = 0
                 found_hash_format = False
+                # FIXME: refactor to allow for multiple hash formats
                 for directory_hash_entry in directory_hash_entries:
                     if directory_hash_entry.hash_format != hash_format:
                         continue
@@ -1208,7 +1217,7 @@ def commit_session_for_collection(
 
     session.commit(creator_info, process_info)
 
-
+# FIXME: refactor to allow for multiple hash formats
 def seal_file_path(existing_history, file_path, hash_format, session) -> (str, bool):
     relative_path = existing_history.get_relative_file_path(file_path)
     file_size = os.path.getsize(file_path)

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -218,6 +218,10 @@ def create_for_folder_subcommand(
     # store the directory hashes of sub folders so we can use it when calculating the hash of the parent folder
     dir_content_hash_mappings = {}
     dir_structure_hash_mappings = {}
+
+    # TODO: Remove once the function signature is updated to supply a hash format list instead of a single format
+    hash_format_list = [hash_format]
+
     for folder_path, children in post_order_lexicographic(root_path, session.ignore_spec.get_path_spec()):
         # generate directory hashes
         dir_hash_context = None
@@ -310,6 +314,9 @@ def create_for_single_files_subcommand(
     session = MHLGenerationCreationSession(existing_history)
 
     num_failed_verifications = 0
+    # TODO: Remove once the function signature is updated to supply a hash format list instead of a single format
+    hash_format_list = [hash_format]
+
     for path in single_file:
         if not os.path.isabs(path):
             path = os.path.join(os.getcwd(), path)
@@ -319,12 +326,12 @@ def create_for_single_files_subcommand(
                     file_path = os.path.join(folder_path, item_name)
                     if is_dir:
                         continue
-                    seal_result = seal_file_path(existing_history, file_path, [hash_format], session)
+                    seal_result = seal_file_path(existing_history, file_path, hash_format_list, session)
                     success = seal_result[hash_format].success
                     if not success:
                         num_failed_verifications += 1
         else:
-            seal_result = seal_file_path(existing_history, file_path, [hash_format], session)
+            seal_result = seal_file_path(existing_history, file_path, hash_format_list, session)
             success = seal_result[hash_format].success
             if not success:
                 num_failed_verifications += 1

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -611,8 +611,8 @@ def verify_directory_hash_subcommand(
 
     # start a verification session on the existing history
     hash_format_list = sorted(hash_formats)
-    # a lookup containing the number of failures detected per hash format
-    failures_per_format_lookup = dict[str, int]()
+    # a lookup containing the number of failures detected per hash format - will match the format Dict[str, int]
+    failures_per_format_lookup = {}
 
     # an inner function responsible for adding format failures to the lookup
     def add_detected_failure_for_format(failed_hash_format):
@@ -632,8 +632,8 @@ def verify_directory_hash_subcommand(
     dir_content_hash_mappings = {}
     dir_structure_hash_mappings = {}
     for folder_path, children in post_order_lexicographic(root_path, ignore_spec.get_path_spec()):
-        # generate directory hashes
-        dir_hash_context_lookup = dict[str, DirectoryHashContext]()
+        # generate directory hashes - will match the format dict[str, DirectoryHashContext]
+        dir_hash_context_lookup = {}
 
         # create a DirectoryHashContext for each hash format and store in the lookup
         for hash_format in hash_format_list:

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -34,6 +34,7 @@ from .traverse import post_order_lexicographic
 from typing import Dict
 from collections import namedtuple
 
+
 @click.command()
 @click.argument("root_path", type=click.Path(exists=True))
 # general options
@@ -236,7 +237,11 @@ def create_for_folder_subcommand(
             if is_dir:
                 if not no_directory_hashes:
                     for hash_format, dir_hash_context in dir_hash_context_lookup.items():
-                        dir_hash_context.append_directory_hashes(file_path, dir_content_hash_mappings.pop(file_path), dir_structure_hash_mappings.pop(file_path))
+                        dir_hash_context.append_directory_hashes(
+                            file_path,
+                            dir_content_hash_mappings.pop(file_path),
+                            dir_structure_hash_mappings.pop(file_path),
+                        )
             else:
                 seal_result = seal_file_path(existing_history, file_path, hash_format_list, session)
 
@@ -269,10 +274,9 @@ def create_for_folder_subcommand(
 
         modification_date = datetime.datetime.fromtimestamp(os.path.getmtime(folder_path))
         # FIXME: refactor to allow for multiple hash formats
-        session.append_multiple_format_directory_hashes(folder_path,
-                                                        modification_date,
-                                                        dir_content_hash_lookup,
-                                                        dir_structure_hash_lookup)
+        session.append_multiple_format_directory_hashes(
+            folder_path, modification_date, dir_content_hash_lookup, dir_structure_hash_lookup
+        )
 
     commit_session(session, author_name, author_email, author_phone, author_role, location, comment)
 
@@ -1266,13 +1270,10 @@ attributes:
 hash_value -- string value, a hash
 success -- boolean value, indicates if the update was successful
 """
-SealPathResult = namedtuple('SealPathResult', ['hash_value', 'success'])
+SealPathResult = namedtuple("SealPathResult", ["hash_value", "success"])
 
 
-def seal_file_path(existing_history,
-                   file_path,
-                   hash_formats: [str],
-                   session) -> Dict[str, SealPathResult]:
+def seal_file_path(existing_history, file_path, hash_formats: [str], session) -> Dict[str, SealPathResult]:
     """
     Generates hashes for a file path.
     Compares the generated hashes to any existing hash records
@@ -1311,11 +1312,9 @@ def seal_file_path(existing_history,
         # in case the existing hash verification failed we don't want to add the current format hash to the generation
         # but we need to return it for directory hash creation
         if success:
-            success &= session.append_file_hash(file_path,
-                                                file_size,
-                                                file_modification_date,
-                                                hash_format,
-                                                current_format_hash)
+            success &= session.append_file_hash(
+                file_path, file_size, file_modification_date, hash_format, current_format_hash
+            )
         hash_result_lookup[hash_format] = SealPathResult(current_format_hash, success)
 
     return hash_result_lookup

--- a/ascmhl/generator.py
+++ b/ascmhl/generator.py
@@ -79,7 +79,7 @@ class MHLGenerationCreationSession:
                 if existing_hash_entry is not None:
                     if existing_hash_entry.hash_string == hash_string:
                         hash_entry.action = "verified"
-                        logger.verbose(f"  verified                      {relative_path}  OK")
+                        logger.verbose(f"  verified                      {relative_path} {hash_format}: OK")
                     else:
                         hash_entry.action = "failed"
                         failures += 1
@@ -93,9 +93,7 @@ class MHLGenerationCreationSession:
                     hash_entry.action = (  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
                         "new"
                     )
-                    logger.verbose(
-                        f"  created new, verified hash for          {relative_path}  {hash_format}: {hash_string}"
-                    )
+                    logger.verbose(f"  created new (verif.) hash for {relative_path}  {hash_format}: {hash_string}")
             # collection behavior: overwrite action with action from flattened history
             if action != None:
                 hash_entry.action = action
@@ -140,7 +138,7 @@ class MHLGenerationCreationSession:
             if existing_hash_entry is not None:
                 if existing_hash_entry.hash_string == hash_string:
                     hash_entry.action = "verified"
-                    logger.verbose(f"  verified                      {relative_path}  OK")
+                    logger.verbose(f"  verified                      {relative_path}  {hash_format}: OK")
                 else:
                     hash_entry.action = "failed"
                     logger.error(
@@ -151,9 +149,7 @@ class MHLGenerationCreationSession:
             else:
                 # in case there is no hash entry for this hash format yet
                 hash_entry.action = "new"  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
-                logger.verbose(
-                    f"  created new, verified hash for          {relative_path}  {hash_format}: {hash_string}"
-                )
+                logger.verbose(f"  created new (verif.) hash for {relative_path}  {hash_format}: {hash_string}")
 
         # in case the same file is hashes multiple times we want to add all hash entries
         new_hash_list = self.new_hash_lists[history]

--- a/ascmhl/generator.py
+++ b/ascmhl/generator.py
@@ -15,6 +15,7 @@ from . import logger
 from .ignore import MHLIgnoreSpec
 from .hashlist import MHLHashList, MHLHashEntry, MHLCreatorInfo, MHLProcessInfo
 from .history import MHLHistory
+from .hasher import HashPair
 
 
 class MHLGenerationCreationSession:
@@ -40,6 +41,85 @@ class MHLGenerationCreationSession:
         self.root_history = history
         self.new_hash_lists = defaultdict(MHLHashList)
         self.ignore_spec = ignore_spec
+
+    def append_file_hashes(self,
+                           file_path,
+                           file_size,
+                           hash_pairs: [HashPair],
+                           file_modification_date,
+                           action=None,
+                           hash_date=None) -> bool:
+        """
+        Adds file hashes to the history
+        :param file_path: a string value representing the path to a file
+        :param file_size: size of the file path in bytes
+        :param hash_pairs: an array of hash values
+        :param file_modification_date: date the file was last modified
+        :param action: a predetermined action for the entry.  defaults to none
+        :param hash_date: date the hashes were generated
+        :return a bool indicating if the hashes were successfully appended.  returns false if any failures occur
+        """
+        relative_path = self.root_history.get_relative_file_path(file_path)
+        # TODO: handle if path is outside of history root path
+        # Keep track of the number of failures
+        failures = 0
+        history, history_relative_path = self.root_history.find_history_for_path(relative_path)
+        # for collections we cannot create a valid relative path (we are in the "wrong" history), but in that case
+        # the file_path is inputted already as the relative path (a bit of implicit functionality here)
+        if history_relative_path == None:
+            history_relative_path = file_path
+
+        # check if there is an existing hash in the other generations and verify
+        original_hash_entry = history.find_original_hash_entry_for_path(history_relative_path)
+
+        hash_entries = [MHLHashEntry]
+
+        for pair in hash_pairs:
+            hash_format = pair.hash_format
+            hash_string = pair.hash_string
+
+            hash_entry = MHLHashEntry(hash_format, hash_string, hash_date=hash_date)
+            if original_hash_entry is None:
+                hash_entry.action = "original"
+                logger.verbose(f"  created original hash for     {relative_path}  {hash_format}: {hash_string}")
+            else:
+                existing_hash_entry = history.find_first_hash_entry_for_path(history_relative_path, hash_format)
+                if existing_hash_entry is not None:
+                    if existing_hash_entry.hash_string == hash_string:
+                        hash_entry.action = "verified"
+                        logger.verbose(f"  verified                      {relative_path}  OK")
+                    else:
+                        hash_entry.action = "failed"
+                        failures += 1
+                        logger.error(
+                            f"ERROR: hash mismatch for        {relative_path}  "
+                            f"{hash_format} (old): {existing_hash_entry.hash_string}, "
+                            f"{hash_format} (new): {hash_string}"
+                        )
+                else:
+                    # in case there is no hash entry for this hash format yet
+                    hash_entry.action = "new"  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
+                    logger.verbose(
+                        f"  created new, verified hash for          {relative_path}  {hash_format}: {hash_string}"
+                    )
+            # collection behavior: overwrite action with action from flattened history
+            if action != None:
+                hash_entry.action = action
+
+            # Add the generated entry to the list
+            hash_entries.append(hash_entry)
+
+        # in case the same file is hashes multiple times we want to add all hash entries
+        new_hash_list = self.new_hash_lists[history]
+        media_hash = new_hash_list.find_or_create_media_hash_for_path(
+            history_relative_path, file_size, file_modification_date
+        )
+
+        # Add the new hash entries
+        for hash_entry in hash_entries:
+            media_hash.append_hash_entry(hash_entry)
+
+        return failures == 0
 
     def append_file_hash(
         self, file_path, file_size, file_modification_date, hash_format, hash_string, action=None, hash_date=None
@@ -93,6 +173,81 @@ class MHLGenerationCreationSession:
 
         media_hash.append_hash_entry(hash_entry)
         return hash_entry.action != "failed"
+
+    def append_directory_hashes(self,
+                                path,
+                                modification_date,
+                                content_hashes: [HashPair],
+                                structure_hashes: [HashPair]) -> None:
+        """
+        Adds directory hashes to the history
+        :param path: a string value representing the path to a file
+        :param modification_date: date the file was last modified
+        :param content_hashes: an array of content hash pairs
+        :param structure_hashes: an array of structure hash pairs
+        :return: none
+        """
+        relative_path = self.root_history.get_relative_file_path(path)
+        # TODO: handle if path is outside of history root path
+
+        history, history_relative_path = self.root_history.find_history_for_path(relative_path)
+
+        # in case the same file is hashes multiple times we want to add all hash entries
+        new_hash_list = self.new_hash_lists[history]
+        media_hash = new_hash_list.find_or_create_media_hash_for_path(history_relative_path, None, modification_date)
+        media_hash.is_directory = True
+
+        # Break the structure hashes down into a lookup
+        structure_lookup = dict[str, str]
+        if structure_hashes:
+            for structure_pair in structure_hashes:
+                structure_lookup[structure_pair.hash_format] = structure_pair.hash_value
+
+        # Add the content entries
+        if content_hashes:
+            for hash_pair in content_hashes:
+                # Add the content entry
+                hash_format = hash_pair.hash_format
+                content_hash_string = hash_pair.hash_string
+                structure_hash_string = structure_lookup[hash_format]
+
+                hash_entry = MHLHashEntry(hash_format, content_hash_string)
+                # Attempt to add the structure, if available
+                hash_entry.structure_hash_string = structure_hash_string
+                media_hash.append_hash_entry(hash_entry)
+
+                if relative_path == ".":
+                    logger.verbose(
+                        f"  calculated root hash  {hash_format}: "
+                        f"{content_hash_string} (content), "
+                        f"{structure_hash_string} (structure)"
+                    )
+                else:
+                    logger.verbose(
+                        f"  calculated directory hash for {relative_path}  {hash_format}: "
+                        f"{content_hash_string} (content), "
+                        f"{structure_hash_string} (structure)"
+                    )
+        else:
+            logger.verbose(f"  added directory entry for     {relative_path}")
+
+        # in case we just created the root media hash of the current hash list we also add it one history level above
+        if new_hash_list.process_info.root_media_hash is media_hash and history.parent_history:
+            parent_history = history.parent_history
+            parent_relative_path = parent_history.get_relative_file_path(path)
+            parent_hash_list = self.new_hash_lists[parent_history]
+            parent_media_hash = parent_hash_list.find_or_create_media_hash_for_path(
+                parent_relative_path, None, modification_date
+            )
+            parent_media_hash.is_directory = True
+            if content_hashes:
+                for hash_pair in content_hashes:
+                    hash_format = hash_pair.hash_format
+                    content_hash_string = hash_pair.hash_string
+                    structure_hash_string = structure_lookup[hash_format]
+                    hash_entry = MHLHashEntry(hash_format, content_hash_string)
+                    hash_entry.structure_hash_string = structure_hash_string
+                    parent_media_hash.append_hash_entry(hash_entry)
 
     def append_directory_hashes(
         self, path, modification_date, hash_format, content_hash_string, structure_hash_string

--- a/ascmhl/generator.py
+++ b/ascmhl/generator.py
@@ -41,13 +41,9 @@ class MHLGenerationCreationSession:
         self.new_hash_lists = defaultdict(MHLHashList)
         self.ignore_spec = ignore_spec
 
-    def append_multiple_format_file_hashes(self,
-                                           file_path,
-                                           file_size,
-                                           hash_lookup: Dict[str, str],
-                                           file_modification_date,
-                                           action=None,
-                                           hash_date=None) -> bool:
+    def append_multiple_format_file_hashes(
+        self, file_path, file_size, hash_lookup: Dict[str, str], file_modification_date, action=None, hash_date=None
+    ) -> bool:
         """
         Adds file hashes to the history
         :param file_path: a string value representing the path to a file
@@ -94,7 +90,9 @@ class MHLGenerationCreationSession:
                         )
                 else:
                     # in case there is no hash entry for this hash format yet
-                    hash_entry.action = "new"  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
+                    hash_entry.action = (  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
+                        "new"
+                    )
                     logger.verbose(
                         f"  created new, verified hash for          {relative_path}  {hash_format}: {hash_string}"
                     )
@@ -170,11 +168,9 @@ class MHLGenerationCreationSession:
         media_hash.append_hash_entry(hash_entry)
         return hash_entry.action != "failed"
 
-    def append_multiple_format_directory_hashes(self,
-                                                path,
-                                                modification_date,
-                                                content_hash_lookup: Dict[str, str],
-                                                structure_hash_lookup: Dict[str, str]) -> None:
+    def append_multiple_format_directory_hashes(
+        self, path, modification_date, content_hash_lookup: Dict[str, str], structure_hash_lookup: Dict[str, str]
+    ) -> None:
         """
         Adds directory hashes to the history
         :param path: a string value representing the path to a file

--- a/ascmhl/hasher.py
+++ b/ascmhl/hasher.py
@@ -449,7 +449,7 @@ def multiple_format_hash_data(input_data: bytes,
     hash_formats -- string values, each entry is one of the supported hash formats, e.g. 'md5', 'xxh64'
     """
     hash_aggregate = AggregateHasher()
-    return hash_aggregate.hash_data(bytes, hash_formats)
+    return hash_aggregate.hash_data(input_data, hash_formats)
 
 
 def bytes_for_hash_string(hash_string: str, hash_format: str) -> bytes:

--- a/ascmhl/hasher.py
+++ b/ascmhl/hasher.py
@@ -16,26 +16,6 @@ from abc import ABC, abstractmethod
 from typing import Dict
 
 
-class HashPair:
-    """
-    HashPair is an explict coupling of a hash value to a defined hash format
-    """
-    def __init__(self, hash_format: str, hash_string: str):
-        """
-        Initializes the pair
-        :param hash_format: string value, one of the supported hash formats, e.g. 'md5', 'xxh64'
-        :param hash_string: A hash string computed from the supplied format
-        """
-        if not hash_format:
-            raise ValueError
-        hash_type = HashType[hash_format]
-        if not hash_type:
-            raise ValueError
-
-        self.hash_format = hash_format
-        self.hash_value = hash_string
-
-
 class Hasher(ABC):
     """
     Hasher is an abstract base class (ABC) that outlines the needed hash functionality by ascmhl.

--- a/ascmhl/hasher.py
+++ b/ascmhl/hasher.py
@@ -227,6 +227,7 @@ class C4(Hasher):
         data = result.to_bytes(64, byteorder="big")
         return data
 
+
 @unique
 class HashType(Enum):
     """
@@ -243,7 +244,6 @@ class HashType(Enum):
 
 
 class AggregateHasher:
-
     def __init__(self, hash_formats: [str]):
 
         # Build a hasher for each format
@@ -257,10 +257,9 @@ class AggregateHasher:
     """
     Handles multiple hashing to facilitate a read-once create-many hashing paradigm
     """
+
     @classmethod
-    def hash_file(cls, 
-                  file_path: str,
-                  hash_formats: [str]) -> Dict[str, str]:
+    def hash_file(cls, file_path: str, hash_formats: [str]) -> Dict[str, str]:
         """
         computes and returns new hash strings for a file
 
@@ -295,9 +294,7 @@ class AggregateHasher:
         return hash_output_lookup
 
     @classmethod
-    def hash_data(cls, 
-                  input_data: bytes, 
-                  hash_formats: [str]) -> Dict[str, str]:
+    def hash_data(cls, input_data: bytes, hash_formats: [str]) -> Dict[str, str]:
         """
         computes and returns new hash strings for a file
 
@@ -394,15 +391,14 @@ def hash_of_hash_list(hash_list: [str], hash_format: str) -> str:
     return hasher.hash_of_hash_list(hash_list)
 
 
-def multiple_format_hash_file(file_path: str,
-                              hash_formats: [str]) -> Dict[str, str]:
+def multiple_format_hash_file(file_path: str, hash_formats: [str]) -> Dict[str, str]:
     """
-     computes and returns a new hash strings for a file
+    computes and returns a new hash strings for a file
 
-     arguments:
-     file_path -- string value, path of file to generate hash for.
-     hash_formats -- string values, each entry is one of the supported hash formats, e.g. 'md5', 'xxh64'
-     """
+    arguments:
+    file_path -- string value, path of file to generate hash for.
+    hash_formats -- string values, each entry is one of the supported hash formats, e.g. 'md5', 'xxh64'
+    """
     return AggregateHasher.hash_file(file_path, hash_formats)
 
 
@@ -430,8 +426,7 @@ def hash_data(input_data: bytes, hash_format: str) -> str:
     return hasher.hash_data(input_data)
 
 
-def multiple_format_hash_data(input_data: bytes,
-                              hash_formats: [str]) -> Dict[str, str]:
+def multiple_format_hash_data(input_data: bytes, hash_formats: [str]) -> Dict[str, str]:
     """
     computes and returns new hash strings from the input data
     arguments:

--- a/ascmhl/hasher.py
+++ b/ascmhl/hasher.py
@@ -403,8 +403,8 @@ def hash_of_hash_list(hash_list: [str], hash_format: str) -> str:
     return hasher.hash_of_hash_list(hash_list)
 
 
-def hash_file(file_path: str,
-              hash_formats: [str]) -> [HashPair]:
+def multiple_format_hash_file(file_path: str,
+                              hash_formats: [str]) -> [HashPair]:
     """
      computes and returns a new hash strings for a file
 
@@ -440,8 +440,8 @@ def hash_data(input_data: bytes, hash_format: str) -> str:
     return hasher.hash_data(input_data)
 
 
-def hash_data(input_data: bytes,
-              hash_formats: [str]) -> [HashPair]:
+def multiple_format_hash_data(input_data: bytes,
+                              hash_formats: [str]) -> [HashPair]:
     """
     computes and returns new hash strings from the input data
     arguments:

--- a/examples/scenarios/Output/scenario_02/log.txt
+++ b/examples/scenarios/Output/scenario_02/log.txt
@@ -25,10 +25,10 @@ this will verify all hashes, check for completeness and create a second generati
 
 $ ascmhl.py create -v /file_server/A002R2EC -h xxh64
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
-  verified                      Sidecar.txt  OK
+  verified                      Sidecar.txt  xxh64: OK
   calculated root hash  xxh64: 8d02114c32e28cbe (content), f557f8ca8e5a88ef (structure)
 Created new generation ascmhl/0002_A002R2EC_2020-01-17_143000.mhl
 

--- a/examples/scenarios/Output/scenario_03/log.txt
+++ b/examples/scenarios/Output/scenario_03/log.txt
@@ -28,13 +28,13 @@ and create a second generation with additional (new) MD5 hashes.
 
 $ ascmhl.py create -v -h md5 /file_server/A002R2EC
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  created new, verified hash for          Clips/A002C006_141024_R2EC.mov  md5: f5ac8127b3b6b85cdc13f237c6005d80
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
-  created new, verified hash for          Clips/A002C007_141024_R2EC.mov  md5: 614dd0e977becb4c6f7fa99e64549b12
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  created new (verif.) hash for Clips/A002C006_141024_R2EC.mov  md5: f5ac8127b3b6b85cdc13f237c6005d80
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
+  created new (verif.) hash for Clips/A002C007_141024_R2EC.mov  md5: 614dd0e977becb4c6f7fa99e64549b12
   calculated directory hash for Clips  md5: 202a2d71b56b080d9b089c1f4f29a4ba (content), 4a739024fd19d928e9dea6bb5c480200 (structure)
-  verified                      Sidecar.txt  OK
-  created new, verified hash for          Sidecar.txt  md5: 6425c5a180ca0f420dd2b25be4536a91
+  verified                      Sidecar.txt  xxh64: OK
+  created new (verif.) hash for Sidecar.txt  md5: 6425c5a180ca0f420dd2b25be4536a91
   calculated root hash  md5: 6fae2da9bc6dca45486cb91bfea6db70 (content), be1f2eaed208efbed061845a64cacdfa (structure)
 Created new generation ascmhl/0002_A002R2EC_2020-01-17_143000.mhl
 

--- a/examples/scenarios/Output/scenario_04/log.txt
+++ b/examples/scenarios/Output/scenario_04/log.txt
@@ -29,8 +29,8 @@ An error is shown and create a new generation that documents the failed verifica
 
 $ ascmhl.py create -v /file_server/A002R2EC -h xxh64
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
 ERROR: hash mismatch for        Sidecar.txt  xxh64 (old): 3ab5a4166b9bde44, xxh64 (new): 70d2cf31aaa3eac4
   calculated root hash  xxh64: 8e52e9c3d15e055c (content), 32706d5f4b48f047 (structure)

--- a/examples/scenarios/Output/scenario_05/log.txt
+++ b/examples/scenarios/Output/scenario_05/log.txt
@@ -45,15 +45,15 @@ of the card sub folders.
 
 $ ascmhl.py create -v /file_server/Reels -h xxh64
 Creating new generation for folder at path: /file_server/Reels ...
-  verified                      A002R2EC/Clips/A002C006_141024_R2EC.mov  OK
-  verified                      A002R2EC/Clips/A002C007_141024_R2EC.mov  OK
+  verified                      A002R2EC/Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      A002R2EC/Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for A002R2EC/Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
-  verified                      A002R2EC/Sidecar.txt  OK
+  verified                      A002R2EC/Sidecar.txt  xxh64: OK
   calculated directory hash for A002R2EC  xxh64: 8d02114c32e28cbe (content), f557f8ca8e5a88ef (structure)
-  verified                      A003R2EC/Clips/A003C011_141024_R2EC.mov  OK
-  verified                      A003R2EC/Clips/A003C012_141024_R2EC.mov  OK
+  verified                      A003R2EC/Clips/A003C011_141024_R2EC.mov  xxh64: OK
+  verified                      A003R2EC/Clips/A003C012_141024_R2EC.mov  xxh64: OK
   calculated directory hash for A003R2EC/Clips  xxh64: f2afc6434255a53d (content), a25d5ca89c95f9e2 (structure)
-  verified                      A003R2EC/Sidecar.txt  OK
+  verified                      A003R2EC/Sidecar.txt  xxh64: OK
   calculated directory hash for A003R2EC  xxh64: 7a82373c131cf40a (content), 1131a950fcc55e4b (structure)
   created original hash for     Summary.txt  xxh64: 0ac48e431d4538ba
   calculated root hash  xxh64: 92950bc8fda076ec (content), 2c2ce52605558158 (structure)

--- a/examples/scenarios/README.md
+++ b/examples/scenarios/README.md
@@ -52,10 +52,10 @@ this will verify all hashes, check for completeness and create a second generati
 
 $ ascmhl.py create -v /file_server/A002R2EC -h xxh64
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
-  verified                      Sidecar.txt  OK
+  verified                      Sidecar.txt  xxh64: OK
   calculated root hash  xxh64: 8d02114c32e28cbe (content), f557f8ca8e5a88ef (structure)
 Created new generation ascmhl/0002_A002R2EC_2020-01-17_143000.mhl
 
@@ -94,13 +94,13 @@ and create a second generation with additional (new) MD5 hashes.
 
 $ ascmhl.py create -v -h md5 /file_server/A002R2EC
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  created new, verified hash for          Clips/A002C006_141024_R2EC.mov  md5: f5ac8127b3b6b85cdc13f237c6005d80
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
-  created new, verified hash for          Clips/A002C007_141024_R2EC.mov  md5: 614dd0e977becb4c6f7fa99e64549b12
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  created new (verif.) hash for Clips/A002C006_141024_R2EC.mov  md5: f5ac8127b3b6b85cdc13f237c6005d80
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
+  created new (verif.) hash for Clips/A002C007_141024_R2EC.mov  md5: 614dd0e977becb4c6f7fa99e64549b12
   calculated directory hash for Clips  md5: 202a2d71b56b080d9b089c1f4f29a4ba (content), 4a739024fd19d928e9dea6bb5c480200 (structure)
-  verified                      Sidecar.txt  OK
-  created new, verified hash for          Sidecar.txt  md5: 6425c5a180ca0f420dd2b25be4536a91
+  verified                      Sidecar.txt  xxh64: OK
+  created new (verif.) hash for Sidecar.txt  md5: 6425c5a180ca0f420dd2b25be4536a91
   calculated root hash  md5: 6fae2da9bc6dca45486cb91bfea6db70 (content), be1f2eaed208efbed061845a64cacdfa (structure)
 Created new generation ascmhl/0002_A002R2EC_2020-01-17_143000.mhl
 
@@ -140,8 +140,8 @@ An error is shown and create a new generation that documents the failed verifica
 
 $ ascmhl.py create -v /file_server/A002R2EC -h xxh64
 Creating new generation for folder at path: /file_server/A002R2EC ...
-  verified                      Clips/A002C006_141024_R2EC.mov  OK
-  verified                      Clips/A002C007_141024_R2EC.mov  OK
+  verified                      Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
 ERROR: hash mismatch for        Sidecar.txt  xxh64 (old): 3ab5a4166b9bde44, xxh64 (new): 70d2cf31aaa3eac4
   calculated root hash  xxh64: 8e52e9c3d15e055c (content), 32706d5f4b48f047 (structure)
@@ -200,15 +200,15 @@ of the card sub folders.
 
 $ ascmhl.py create -v /file_server/Reels -h xxh64
 Creating new generation for folder at path: /file_server/Reels ...
-  verified                      A002R2EC/Clips/A002C006_141024_R2EC.mov  OK
-  verified                      A002R2EC/Clips/A002C007_141024_R2EC.mov  OK
+  verified                      A002R2EC/Clips/A002C006_141024_R2EC.mov  xxh64: OK
+  verified                      A002R2EC/Clips/A002C007_141024_R2EC.mov  xxh64: OK
   calculated directory hash for A002R2EC/Clips  xxh64: 4c226b42e27d7af3 (content), 906faa843d591a9f (structure)
-  verified                      A002R2EC/Sidecar.txt  OK
+  verified                      A002R2EC/Sidecar.txt  xxh64: OK
   calculated directory hash for A002R2EC  xxh64: 8d02114c32e28cbe (content), f557f8ca8e5a88ef (structure)
-  verified                      A003R2EC/Clips/A003C011_141024_R2EC.mov  OK
-  verified                      A003R2EC/Clips/A003C012_141024_R2EC.mov  OK
+  verified                      A003R2EC/Clips/A003C011_141024_R2EC.mov  xxh64: OK
+  verified                      A003R2EC/Clips/A003C012_141024_R2EC.mov  xxh64: OK
   calculated directory hash for A003R2EC/Clips  xxh64: f2afc6434255a53d (content), a25d5ca89c95f9e2 (structure)
-  verified                      A003R2EC/Sidecar.txt  OK
+  verified                      A003R2EC/Sidecar.txt  xxh64: OK
   calculated directory hash for A003R2EC  xxh64: 7a82373c131cf40a (content), 1131a950fcc55e4b (structure)
   created original hash for     Summary.txt  xxh64: 0ac48e431d4538ba
   calculated root hash  xxh64: 92950bc8fda076ec (content), 2c2ce52605558158 (structure)

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,16 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    author="Patrick Renner, Alexander Sahm",
+    author="The ASC MHL Working Group (Alex Sahm, Ben Hagen, Jon Waggoner, Mark Hudgins, Patrick Renner, and others.)",
     author_email="opensource@pomfort.com",
     description="ASC Media Hash List (ASC MHL)",
-    entry_points={"console_scripts": ["ascmhl = ascmhl.cli.ascmhl:mhltool_cli"]},
+    entry_points={
+        "console_scripts": [
+            "ascmhl = ascmhl.cli.ascmhl:mhltool_cli",
+            "ascmhl-debug = ascmhl.cli.ascmhl_debug:mhldebugtool_cli",
+            # "ascmhl-dev = ascmhl.cli.ascmhl_dev:mhldevtool_cli",
+        ]
+    },
     include_package_data=True,
     install_requires=[
         "Click>=7.0",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -319,3 +319,12 @@ def test_create_mulitple_hashformats(fs, simple_mhl_history):
 
     assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
     assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output
+
+
+def test_create_mulitple_hashformats_no_dash_n(fs, simple_mhl_history):
+    runner = CliRunner()
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "md5", "-h", "sha1"])
+    assert result.exit_code == 0
+
+    assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
+    assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -328,3 +328,4 @@ def test_create_mulitple_hashformats_no_dash_n(fs, simple_mhl_history):
 
     assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
     assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output
+    

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -310,3 +310,12 @@ def test_creator_info(fs, simple_mhl_history):
     assert "franz@example.com" in result.output
     assert "123-4567" in result.output
     assert "Data Manager" in result.output
+
+
+def test_create_mulitple_hashformats(fs, simple_mhl_history):
+    runner = CliRunner()
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-n", "-h", "md5", "-h", "sha1"])
+    assert result.exit_code == 0
+
+    assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
+    assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -98,13 +98,13 @@ def test_create_directory_hashes(fs):
         file.write("!!")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "xxh64", "-h", "md5"])
     assert "ERROR: hash mismatch for        A/A2.txt" in result.output
     hash_list = MHLHistory.load_from_path("/root").hash_lists[-1]
     # an altered file leads to a different root directory hash
-    assert hash_list.process_info.root_media_hash.hash_entries[0].hash_string == "28ed09733f793dfc"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].hash_string == "28ed09733f793dfc"
     # structure hash stays the same
-    assert hash_list.process_info.root_media_hash.hash_entries[0].structure_hash_string == "89e4debdb80cc068"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].structure_hash_string == "89e4debdb80cc068"
 
     # test that the directory-hash command creates the same root hash
     # FIXME: command doesn't exist any more, replace with tests of verify directory hashes command?
@@ -112,29 +112,44 @@ def test_create_directory_hashes(fs):
     #    assert result.exit_code == 0
     #    assert "root hash: xxh64: adf18c910489663c" in result.output
 
-    assert hash_list.find_media_hash_for_path("B").hash_entries[0].hash_string == "aab0eba57cd1aca9"
-    assert hash_list.find_media_hash_for_path("B").hash_entries[0].structure_hash_string == "fac2a2ceb0fa0c0b"
-    assert hash_list.process_info.root_media_hash.hash_entries[0].hash_string == "28ed09733f793dfc"
-    assert hash_list.process_info.root_media_hash.hash_entries[0].structure_hash_string == "89e4debdb80cc068"
+    assert hash_list.find_media_hash_for_path("B").hash_entries[0].hash_string == "d6df246725efff6ceaee31f663a32cf8"
+    assert hash_list.find_media_hash_for_path("B").hash_entries[1].hash_string == "aab0eba57cd1aca9"
+
+    assert (
+        hash_list.find_media_hash_for_path("B").hash_entries[0].structure_hash_string
+        == "a21e164c1df944733e5e3d4e4ed64f90"
+    )
+    assert hash_list.find_media_hash_for_path("B").hash_entries[1].structure_hash_string == "fac2a2ceb0fa0c0b"
+
+    assert hash_list.process_info.root_media_hash.hash_entries[1].hash_string == "28ed09733f793dfc"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].structure_hash_string == "89e4debdb80cc068"
 
     # rename one file
     os.rename("/root/B/B1.txt", "/root/B/B2.txt")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "xxh64", "-h", "c4"])
     assert "ERROR: hash mismatch for        A/A2.txt" in result.output
     # in addition to the failing verification we also have a missing file B1/B1.txt
     assert "missing file(s):\n  B/B1.txt" in result.output
     hash_list = MHLHistory.load_from_path("/root").hash_lists[-1]
     # the file name is part of the structure directory hash of the containing directory so it's hash changes
-    assert hash_list.find_media_hash_for_path("B").hash_entries[0].structure_hash_string == "7ae620e883160eb3"
+    assert (
+        hash_list.find_media_hash_for_path("B").hash_entries[0].structure_hash_string
+        == "c42qegPDBxh16Vqi4qFGh1EQv39nEbVmZ9R1LGkaVr1dEBRcD69pH3r5vdGDSwceQLEZc872kQho5Cforb95s2wjH8"
+    )
+    assert hash_list.find_media_hash_for_path("B").hash_entries[1].structure_hash_string == "7ae620e883160eb3"
     # .. and the content hash stays the same
-    assert hash_list.find_media_hash_for_path("B").hash_entries[0].hash_string == "aab0eba57cd1aca9"
+    assert (
+        hash_list.find_media_hash_for_path("B").hash_entries[0].hash_string
+        == "c43X1ve8nmicwGit4fnhs428pTCV6ZjXQsorxPLNx3396oRuQFaq79iLR2ZsPoWN8yckFzZdkqZ21igH8K7rWAoDMa"
+    )
+    assert hash_list.find_media_hash_for_path("B").hash_entries[1].hash_string == "aab0eba57cd1aca9"
 
     # a renamed file also leads to a different root structure directory hash
-    assert hash_list.process_info.root_media_hash.hash_entries[0].structure_hash_string == "0bba67923d19d36b"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].structure_hash_string == "0bba67923d19d36b"
     # and an unchanged content hash
-    assert hash_list.process_info.root_media_hash.hash_entries[0].hash_string == "28ed09733f793dfc"
+    assert hash_list.process_info.root_media_hash.hash_entries[1].hash_string == "28ed09733f793dfc"
 
     # test that the directory-hash command creates the same root hash
     # FIXME: command doesn't exist any more, replace with tests of verify directory hashes command?

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -343,3 +343,21 @@ def test_create_mulitple_hashformats_no_dash_n(fs, simple_mhl_history):
 
     assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
     assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output
+
+
+@freeze_time("2020-01-16 09:15:00")
+def test_create_mulitple_hashformats_double_hashformat(fs, simple_mhl_history):
+    runner = CliRunner()
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "c4"])
+    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-h", "md5", "-h", "sha1"])
+
+    # check if mhl file exists
+    mhlfilepath = "/root/ascmhl/0003_root_2020-01-16_091500.mhl"
+    assert os.path.isfile(mhlfilepath)
+
+    # check if mhl file validates
+    result = runner.invoke(ascmhl.commands.xsd_schema_check, [mhlfilepath])
+    if result.exit_code != 0:
+        print(result.output)
+
+    assert result.exit_code == 0

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -328,4 +328,3 @@ def test_create_mulitple_hashformats_no_dash_n(fs, simple_mhl_history):
 
     assert "A/A1.txt  md5: fe6975a937016c20b43b17540e6c6246" in result.output
     assert "A/A1.txt  sha1: 4a5b95edbea7de5ed2367432645df88cd4f1d1b6" in result.output
-    

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -53,14 +53,14 @@ def test_aggregate_hashing_of_data(fs):
     }
 
     # Generate the hash pairings for the file and specified formats
-    hash_pairs = multiple_format_hash_data(data, hash_type_and_value.keys())
+    hash_lookup = multiple_format_hash_data(data, hash_type_and_value.keys())
 
     # Make sure each pair's value matches the known hash value
     evaluated_formats = []
-    for pair in hash_pairs:
-        known_hash = hash_type_and_value[pair.hash_format]
-        evaluated_formats.append(pair.hash_format)
-        assert pair.hash_value == known_hash
+    for hash_format, hash_value in hash_lookup.items():
+        known_hash = hash_type_and_value[hash_format]
+        evaluated_formats.append(hash_format)
+        assert hash_value == known_hash
 
     # Make sure each stored format was represented in the hash pairings
     for k in hash_type_and_value:
@@ -103,14 +103,14 @@ def test_aggregate_hashing_of_file(fs):
     }
 
     # Generate the hash pairings for the file and specified formats
-    hash_pairs = multiple_format_hash_file(file, hash_type_and_value.keys())
+    hash_lookup = multiple_format_hash_file(file, hash_type_and_value.keys())
 
     # Make sure each pair's value matches the known hash value
     evaluated_formats = []
-    for pair in hash_pairs:
-        known_hash = hash_type_and_value[pair.hash_format]
-        evaluated_formats.append(pair.hash_format)
-        assert pair.hash_value == known_hash
+    for hash_format, hash_value in hash_lookup.items():
+        known_hash = hash_type_and_value[hash_format]
+        evaluated_formats.append(hash_format)
+        assert hash_value == known_hash
 
     # Make sure each stored format was represented in the hash pairings
     for k in hash_type_and_value:

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -37,6 +37,42 @@ def test_hash_data():
         assert h == v  # assert our computed hash equals expected hash
 
 
+def test_aggregate_hashing_of_data(fs):
+    # the data to hash
+    data = b"media-hash-list"
+
+    # map of hash algorithm to expected hash value
+    hash_type_and_value = {
+        "md5": "9db0fc9f30f5ee70041a7538809e2858",
+        "sha1": "7b57673ac5633937a55b59009ad0c57ee08188b7",
+        "xxh32": "f67c5a4f",
+        "xxh64": "584b2ea1974f2b7c",
+        "xxh3": "6d4cbd75905c81aa",
+        "xxh128": "61a67c014f703a456ee7a776fd8c06bd",
+        "c4": "c456LycWwpMMS7VDZEKvYv2L1uJS6s4qAFnaJdnQiy5JVbBFZMA8aLDS6SPaJjLqxXH4qZdnbuktopMt9frtC2qL1R",
+    }
+
+    # Get a list of all the hash formats
+    hash_formats = []
+
+    for k in hash_type_and_value:
+        hash_formats.append(k)
+
+    # Generate the hash pairings for the file and specified formats
+    hash_pairs = multiple_format_hash_data(data, hash_formats)
+
+    # Make sure each pair's value matches the known hash value
+    evaluated_formats = []
+    for pair in hash_pairs:
+        known_hash = hash_type_and_value[pair.hash_format]
+        evaluated_formats.append(pair.hash_format)
+        assert pair.hash_value == known_hash
+
+    # Make sure each stored format was represented in the hash pairings
+    for k in hash_type_and_value:
+        assert k in evaluated_formats
+
+
 def test_hash_file(fs):
     # write some data to a file so we can hash it.
     file, data = "/data-file.txt", "media-hash-list"
@@ -55,6 +91,42 @@ def test_hash_file(fs):
     for k, v in hash_type_and_value.items():
         h = hash_file(file, k)
         assert h == v  # assert our computed hash equals expected hash
+
+
+def test_aggregate_hashing_of_file(fs):
+    # write some data to a file so we can hash it.
+    file, data = "/data-file.txt", "media-hash-list"
+    fs.create_file(file, contents=data)
+    # map of hash algorithm to expected hash value
+    hash_type_and_value = {
+        "md5": "9db0fc9f30f5ee70041a7538809e2858",
+        "sha1": "7b57673ac5633937a55b59009ad0c57ee08188b7",
+        "xxh32": "f67c5a4f",
+        "xxh64": "584b2ea1974f2b7c",
+        "xxh3": "6d4cbd75905c81aa",
+        "xxh128": "61a67c014f703a456ee7a776fd8c06bd",
+        "c4": "c456LycWwpMMS7VDZEKvYv2L1uJS6s4qAFnaJdnQiy5JVbBFZMA8aLDS6SPaJjLqxXH4qZdnbuktopMt9frtC2qL1R",
+    }
+
+    # Get a list of all the hash formats
+    hash_formats = []
+
+    for k in hash_type_and_value:
+        hash_formats.append(k)
+
+    # Generate the hash pairings for the file and specified formats
+    hash_pairs = multiple_format_hash_file(file, hash_formats)
+
+    # Make sure each pair's value matches the known hash value
+    evaluated_formats = []
+    for pair in hash_pairs:
+        known_hash = hash_type_and_value[pair.hash_format]
+        evaluated_formats.append(pair.hash_format)
+        assert pair.hash_value == known_hash
+
+    # Make sure each stored format was represented in the hash pairings
+    for k in hash_type_and_value:
+        assert k in evaluated_formats
 
 
 def test_hash_of_hash_list():

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -52,14 +52,8 @@ def test_aggregate_hashing_of_data(fs):
         "c4": "c456LycWwpMMS7VDZEKvYv2L1uJS6s4qAFnaJdnQiy5JVbBFZMA8aLDS6SPaJjLqxXH4qZdnbuktopMt9frtC2qL1R",
     }
 
-    # Get a list of all the hash formats
-    hash_formats = []
-
-    for k in hash_type_and_value:
-        hash_formats.append(k)
-
     # Generate the hash pairings for the file and specified formats
-    hash_pairs = multiple_format_hash_data(data, hash_formats)
+    hash_pairs = multiple_format_hash_data(data, hash_type_and_value.keys())
 
     # Make sure each pair's value matches the known hash value
     evaluated_formats = []
@@ -108,14 +102,8 @@ def test_aggregate_hashing_of_file(fs):
         "c4": "c456LycWwpMMS7VDZEKvYv2L1uJS6s4qAFnaJdnQiy5JVbBFZMA8aLDS6SPaJjLqxXH4qZdnbuktopMt9frtC2qL1R",
     }
 
-    # Get a list of all the hash formats
-    hash_formats = []
-
-    for k in hash_type_and_value:
-        hash_formats.append(k)
-
     # Generate the hash pairings for the file and specified formats
-    hash_pairs = multiple_format_hash_file(file, hash_formats)
+    hash_pairs = multiple_format_hash_file(file, hash_type_and_value.keys())
 
     # Make sure each pair's value matches the known hash value
     evaluated_formats = []


### PR DESCRIPTION
- introduced `ascmhl-debug` tool (now with verify, xsd-schema-check, hash commands)
- removing `verify` command from `ascmhl` tool
- adapting README