### PR TITLE
Fix for "sequencenr" attribute in chain and collection file

### DIFF
--- a/ascmhl/chain_xml_parser.py
+++ b/ascmhl/chain_xml_parser.py
@@ -57,7 +57,7 @@ def parse(file_path):
                         current_object.hash_format = tag
                         current_object.hash_string = element.text
                     elif tag == "hashlist":
-                        current_object.generation_number = element.attrib.get("sequencer")
+                        current_object.generation_number = element.attrib.get("sequencenr")
                         chain.append_generation(current_object)
                         current_object = None
 
@@ -106,7 +106,7 @@ def _hashlist_xml_element_from_hashlist(hash_list: MHLHashList):
         E.path(os.path.basename(hash_list.file_path)),
         E.c4(hash_list.generate_reference_hash()),
     )
-    hash_list_element.attrib["sequencer"] = str(hash_list.generation_number)
+    hash_list_element.attrib["sequencenr"] = str(hash_list.generation_number)
 
     return hash_list_element
 
@@ -119,7 +119,7 @@ def _hashlist_xml_element_from_chaingeneration(generation: MHLChainGeneration):
             E.path(generation.ascmhl_filename),
             E.c4(generation.hash_string),
         )
-        hash_list_element.attrib["sequencer"] = str(generation.generation_number)
+        hash_list_element.attrib["sequencenr"] = str(generation.generation_number)
 
         return hash_list_element
     else:

--- a/examples/scenarios/Output/scenario_01/travel_01/A002R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_01/travel_01/A002R2EC/ascmhl/ascmhl_chain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A002R2EC_2020-01-16_091500.mhl</path>
     <c4>c43qQABrjeiU3kteaNFtgwufQRLKxgMJEZfNSj6LcZ8fKwB568U8As9eScRsnb64NfqiAYzjNUXs81tAxPB77PUThb</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_02/file_server/A002R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_02/file_server/A002R2EC/ascmhl/ascmhl_chain.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A002R2EC_2020-01-16_091500.mhl</path>
     <c4>c43qQABrjeiU3kteaNFtgwufQRLKxgMJEZfNSj6LcZ8fKwB568U8As9eScRsnb64NfqiAYzjNUXs81tAxPB77PUThb</c4>
   </hashlist>
-  <hashlist sequencer="2">
+  <hashlist sequencenr="2">
     <path>0002_A002R2EC_2020-01-17_143000.mhl</path>
     <c4>c45kfAU9bNHnT32pMzSdio6Qb7us3xkd65ff8uAvJcgdkpoQZUKoPFckwtVHozxgftZj4uUoXrRiAiwSqNGAxLUAKM</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_02/travel_01/A002R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_02/travel_01/A002R2EC/ascmhl/ascmhl_chain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A002R2EC_2020-01-16_091500.mhl</path>
     <c4>c43qQABrjeiU3kteaNFtgwufQRLKxgMJEZfNSj6LcZ8fKwB568U8As9eScRsnb64NfqiAYzjNUXs81tAxPB77PUThb</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_03/file_server/A002R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_03/file_server/A002R2EC/ascmhl/ascmhl_chain.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A002R2EC_2020-01-16_091500.mhl</path>
     <c4>c43qQABrjeiU3kteaNFtgwufQRLKxgMJEZfNSj6LcZ8fKwB568U8As9eScRsnb64NfqiAYzjNUXs81tAxPB77PUThb</c4>
   </hashlist>
-  <hashlist sequencer="2">
+  <hashlist sequencenr="2">
     <path>0002_A002R2EC_2020-01-17_143000.mhl</path>
     <c4>c422u4PnnuStBK5Q9Wv4uFHagkFaK9AfZNcM4nbXuCKWTUikSWWfeeszSUnM2omfCoKnsZHJZNptSBZsumZMJy6Woy</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_03/travel_01/A002R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_03/travel_01/A002R2EC/ascmhl/ascmhl_chain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A002R2EC_2020-01-16_091500.mhl</path>
     <c4>c43qQABrjeiU3kteaNFtgwufQRLKxgMJEZfNSj6LcZ8fKwB568U8As9eScRsnb64NfqiAYzjNUXs81tAxPB77PUThb</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_04/file_server/A002R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_04/file_server/A002R2EC/ascmhl/ascmhl_chain.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A002R2EC_2020-01-16_091500.mhl</path>
     <c4>c43qQABrjeiU3kteaNFtgwufQRLKxgMJEZfNSj6LcZ8fKwB568U8As9eScRsnb64NfqiAYzjNUXs81tAxPB77PUThb</c4>
   </hashlist>
-  <hashlist sequencer="2">
+  <hashlist sequencenr="2">
     <path>0002_A002R2EC_2020-01-17_143000.mhl</path>
     <c4>c444PGVUrtKnV3Gg3JeoUquS3Yjzz2aipSy81eLJgLSGCFJCkqSJ5hp9sJxDY97DmsMycSg9YRx7gcfrSK2j9f1AWK</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_04/travel_01/A002R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_04/travel_01/A002R2EC/ascmhl/ascmhl_chain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A002R2EC_2020-01-16_091500.mhl</path>
     <c4>c43qQABrjeiU3kteaNFtgwufQRLKxgMJEZfNSj6LcZ8fKwB568U8As9eScRsnb64NfqiAYzjNUXs81tAxPB77PUThb</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_05/file_server/Reels/A002R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_05/file_server/Reels/A002R2EC/ascmhl/ascmhl_chain.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A002R2EC_2020-01-16_091500.mhl</path>
     <c4>c43qQABrjeiU3kteaNFtgwufQRLKxgMJEZfNSj6LcZ8fKwB568U8As9eScRsnb64NfqiAYzjNUXs81tAxPB77PUThb</c4>
   </hashlist>
-  <hashlist sequencer="2">
+  <hashlist sequencenr="2">
     <path>0002_A002R2EC_2020-01-17_143000.mhl</path>
     <c4>c45kfAU9bNHnT32pMzSdio6Qb7us3xkd65ff8uAvJcgdkpoQZUKoPFckwtVHozxgftZj4uUoXrRiAiwSqNGAxLUAKM</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_05/file_server/Reels/A003R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_05/file_server/Reels/A003R2EC/ascmhl/ascmhl_chain.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A003R2EC_2020-01-16_091500.mhl</path>
     <c4>c45zb4dbxTLtvaLg3hZX1ds9fc7RjKoi5UtQ4N9oFHo51v7mrhUJR8Kn5uY7aBjmkYwRN9bgF57A4LJM3nrN1dT5hQ</c4>
   </hashlist>
-  <hashlist sequencer="2">
+  <hashlist sequencenr="2">
     <path>0002_A003R2EC_2020-01-17_143000.mhl</path>
     <c4>c42zP4mMY3CEpYEM9F9xde62ZbdmwRBc5gne7basp6RfZ11tZQxwcS95Gyhbrpea76em3aPE3Q823657oT27rrFYhB</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_05/file_server/Reels/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_05/file_server/Reels/ascmhl/ascmhl_chain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_Reels_2020-01-17_143000.mhl</path>
     <c4>c43otc1g6jauN2XVh6wNU4sST4f52w9WAxwDHrCs4FtnuJSSvDo9SsZ5mofYWVfzKi37YFyu8Nhn8dCAkT1WjCATE9</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_05/travel_01/Reels/A002R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_05/travel_01/Reels/A002R2EC/ascmhl/ascmhl_chain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A002R2EC_2020-01-16_091500.mhl</path>
     <c4>c43qQABrjeiU3kteaNFtgwufQRLKxgMJEZfNSj6LcZ8fKwB568U8As9eScRsnb64NfqiAYzjNUXs81tAxPB77PUThb</c4>
   </hashlist>

--- a/examples/scenarios/Output/scenario_05/travel_01/Reels/A003R2EC/ascmhl/ascmhl_chain.xml
+++ b/examples/scenarios/Output/scenario_05/travel_01/Reels/A003R2EC/ascmhl/ascmhl_chain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-  <hashlist sequencer="1">
+  <hashlist sequencenr="1">
     <path>0001_A003R2EC_2020-01-16_091500.mhl</path>
     <c4>c45zb4dbxTLtvaLg3hZX1ds9fc7RjKoi5UtQ4N9oFHo51v7mrhUJR8Kn5uY7aBjmkYwRN9bgF57A4LJM3nrN1dT5hQ</c4>
   </hashlist>

--- a/xsd/ASCMHLDirectory.xsd
+++ b/xsd/ASCMHLDirectory.xsd
@@ -17,7 +17,7 @@
 			<element name="path" type="ascmhl:RelativePathType"/>
 			<element name="c4" type="ascmhl:HashFormatType"/>
 		</sequence>
-		<attribute name="sequencer" type="integer"/>
+		<attribute name="sequencenr" type="integer"/>
 	</complexType>
 	<element name="ascmhldirectory" type="ascmhldirectory:DirectoryType"/>
 </schema>

--- a/xsd/examples/ascmhl_chain.xml
+++ b/xsd/examples/ascmhl_chain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ascmhldirectory xmlns="urn:ASC:MHL:DIRECTORY:v2.0">
-    <hashlist sequencer="1">
+    <hashlist sequencenr="1">
         <path>0001_TEST01_2019-10-11_155603.mhl</path>
         <c4>c44pdRyHLMvHsYbJnRpTrh5ohdWW6uVbm4mZx421aTN7y9MUKk74TqyshmTLgvnq2tcZex6khpxrYUq87Hczcmnyq3</c4>
     </hashlist>


### PR DESCRIPTION
Was `sequencer=` instead of `sequencenr=` in the `<hashlist>` element of chain and collection files.