### PR TITLE
fix errors and issues with optional roothash

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 > the [American Society of Cinematographers](https://theasc.com) (ASC). 
 >
 > Resources:
-> * 🌎 [ASC MHL Homepage](http://ascmhl.com/) (at [http://ascmhl.com/](http://ascmhl.com/))
 > * 📄 [ASC MHL Specification page](https://theasc.com/asc/asc-media-hash-list) (at [theasc.com](https://theasc.com))
 > 
 > In case you are looking for the original specification of MHL, please take a look at 

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -1272,7 +1272,13 @@ def info_for_single_file(root_path, verbose, single_file):
     is_flag=True,
     help="Check directory file (e.g. ascmhl_chain.xml) instead of manifest file",
 )
-def xsd_schema_check(file_path, directory_file):
+@click.option(
+    "--xsd_file",
+    "-xsd",
+    default=None,
+    help="Path to the xsd file",
+)
+def xsd_schema_check(file_path, directory_file, xsd_file):
     """
     Checks a .mhl file against the xsd schema definition
 
@@ -1287,6 +1293,9 @@ def xsd_schema_check(file_path, directory_file):
 
     if directory_file:
         xsd_path = "xsd/ASCMHLDirectory__combined.xsd"
+
+    if xsd_file != None:
+        xsd_path = xsd_file
 
     xsd = etree.XMLSchema(etree.parse(xsd_path))
 

--- a/ascmhl/hashlist_xml_parser.py
+++ b/ascmhl/hashlist_xml_parser.py
@@ -366,11 +366,18 @@ def _process_info_xml_element(hash_list: MHLHashList):
     if root_hash.path == ".":  # TODO: can we find out if this is a non-flattened history further up?
         root_hash.path = hash_list.get_root_path()
 
-    info_element = E.processinfo(
-        E.process(process_info.process.process_type),
-        _root_media_hash_xml_element(root_hash),
-        _ignorespec_xml_element(hash_list.process_info.ignore_spec),
-    )
+    if root_hash is not None and len(root_hash.hash_entries) > 0:
+        info_element = E.processinfo(
+            E.process(process_info.process.process_type),
+            _root_media_hash_xml_element(root_hash),
+            _ignorespec_xml_element(hash_list.process_info.ignore_spec),
+        )
+    else:
+        info_element = E.processinfo(
+            E.process(process_info.process.process_type),
+            _ignorespec_xml_element(hash_list.process_info.ignore_spec),
+        )
+
     return info_element
 
 

--- a/ascmhl/history.py
+++ b/ascmhl/history.py
@@ -231,8 +231,9 @@ class MHLHistory:
                         generation_number = int(parts[0][0])
                         hash_list.generation_number = generation_number
                         # FIXME is there a better way of accessing the generation from a hash entry?
-                        for hash_entry in hash_list.process_info.root_media_hash.hash_entries:
-                            hash_entry.temp_generation_number = hash_list.generation_number
+                        if hash_list.process_info.root_media_hash is not None:
+                            for hash_entry in hash_list.process_info.root_media_hash.hash_entries:
+                                hash_entry.temp_generation_number = hash_list.generation_number
                         hash_lists.append(hash_list)
                     else:
                         logger.error(f"name of ascmhl file {filename} does not conform to naming convention")

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -175,7 +175,7 @@ def test_create_no_directory_hashes(fs):
     assert hash_list.find_media_hash_for_path("A").is_directory
     assert len(hash_list.find_media_hash_for_path("A").hash_entries) == 0
     # and no directory hash of the root folder is set in the header
-    assert len(hash_list.process_info.root_media_hash.hash_entries) == 0
+    assert hash_list.process_info.root_media_hash == None
     # the empty folder is still referenced even if not creating directory hashes
     assert hash_list.find_media_hash_for_path("emptyFolder").is_directory
 


### PR DESCRIPTION
* The `create` command doesn't add empty `<roothash>` element any more when skipping directory hashes (with `-n` option).
* Missing (optional) `<roothash>` tag doesn't lead to errors any more.