### PR TITLE
Fix: Display nested histories above nesting level 1

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -1184,7 +1184,11 @@ def info_for_entire_history(root_path, verbose):
     if len(existing_history.hash_lists) == 0:
         raise errors.NoMHLHistoryException(root_path)
 
-    for hash_list in existing_history.hash_lists:
+    log_child_histories(existing_history)
+
+
+def log_child_histories(history):
+    for hash_list in history.hash_lists:
         if logger.verbose_logging == True:
             creatorInfo = hash_list.creator_info.summary()
             processInfo = hash_list.process_info.summary()
@@ -1196,25 +1200,9 @@ def info_for_entire_history(root_path, verbose):
         else:
             logger.info(f"  Generation {hash_list.generation_number} ({hash_list.creator_info.creation_date})")
 
-        if len(existing_history.child_histories) > 0:
-            if logger.verbose_logging == True:
-                for child_history in existing_history.child_histories:
-                    logger.info(f"\nChild History at {child_history.get_root_path()}:")
-                    for hash_list in child_history.hash_lists:
-                        if logger.verbose_logging == True:
-                            creatorInfo = hash_list.creator_info.summary()
-                            processInfo = hash_list.process_info.summary()
-                            logger.info(
-                                f"  Generation {hash_list.generation_number} ({hash_list.creator_info.creation_date})\n"
-                                f"     CreatorInfo: {creatorInfo}\n"
-                                f"     ProcessInfo: {processInfo}"
-                            )
-                        else:
-                            logger.info(
-                                f"  Generation {hash_list.generation_number} ({hash_list.creator_info.creation_date})"
-                            )
-            else:
-                logger.info(f"  Child Histories: {len(existing_history.child_histories)}")
+    for child_history in history.child_histories:
+        logger.info(f"\nChild History at {child_history.get_root_path()}:")
+        log_child_histories(child_history)
 
 
 def info_for_single_file(root_path, verbose, single_file):


### PR DESCRIPTION
This pull request addresses a limitation in the display of nested histories. Previously, only histories at nesting level 1 were being shown, leading to incomplete output. 