### PR TITLE
adding new error code for missing manifest file

### DIFF
--- a/ascmhl/errors.py
+++ b/ascmhl/errors.py
@@ -59,7 +59,7 @@ class ModifiedMHLManifestFileException(click.ClickException):
         super().__init__(f"Modified ASC MHL manifest in history at path {path}")
 
 
-class NoMHLChainExceptionForPath(click.ClickException):
+class NoMHLChainException(click.ClickException):
     exit_code = 32
 
     def __init__(self, path):

--- a/ascmhl/errors.py
+++ b/ascmhl/errors.py
@@ -52,15 +52,22 @@ class NoMHLHistoryException(click.ClickException):
         super().__init__(f"Missing ASC MHL history at path {path}")
 
 
-class ModifiedMHLHistoryFile(click.ClickException):
+class ModifiedMHLManifestFileException(click.ClickException):
     exit_code = 31
 
     def __init__(self, path):
-        super().__init__(f"Modified ASC MHL history at path {path}")
+        super().__init__(f"Modified ASC MHL manifest in history at path {path}")
 
 
 class NoMHLChainExceptionForPath(click.ClickException):
     exit_code = 32
 
     def __init__(self, path):
-        super().__init__(f"Missing ASC MHL history for path {path}")
+        super().__init__(f"Missing ASC MHL chain file for path {path}")
+
+
+class MissingMHLManifestException(click.ClickException):
+    exit_code = 33
+
+    def __init__(self, path):
+        super().__init__(f"Missing ASC MHL manifest in history at path {path}")

--- a/ascmhl/history.py
+++ b/ascmhl/history.py
@@ -226,7 +226,7 @@ class MHLHistory:
 
         file_path = os.path.join(asc_mhl_folder_path, ascmhl_chainfile_name)
         if os.path.exists(asc_mhl_folder_path) and not os.path.exists(file_path):
-            raise errors.NoMHLChainExceptionForPath(file_path)
+            raise errors.NoMHLChainException(file_path)
         history.chain = chain_xml_parser.parse(file_path)
         if history.chain.generations:
             for generation in history.chain.generations:

--- a/ascmhl/history.py
+++ b/ascmhl/history.py
@@ -234,9 +234,9 @@ class MHLHistory:
                 if os.path.exists(expected_file):
                     hash = hasher.hash_file(expected_file, generation.hash_format)
                     if hash != generation.hash_string:
-                        raise errors.ModifiedMHLHistoryFile(expected_file)
+                        raise errors.ModifiedMHLManifestFileException(expected_file)
                 else:
-                    raise errors.NoMHLHistoryException(expected_file)
+                    raise errors.MissingMHLManifestException(expected_file)
 
         hash_lists = []
         for root, directories, filenames in os.walk(asc_mhl_folder_path):

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -145,11 +145,11 @@ def test_create_nested_mhl_file_missing(fs):
     os.remove("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl")
     result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
     assert result.exception
-    assert result.exit_code == 30
+    assert result.exit_code == 33
 
     result = runner.invoke(ascmhl.commands.diff, ["/root"])
     assert result.exception
-    assert result.exit_code == 30
+    assert result.exit_code == 33
 
 
 @freeze_time("2020-01-16 09:15:00")


### PR DESCRIPTION
Missing manifest (i.e. *mhl file) and missing history (i.e. entire ascmhl folder) had same error code, is now separate.