### PR TITLE
Fix author info to conform to structure in spec

### DIFF
--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -1434,7 +1434,7 @@ def commit_session(session, author_name, author_email, author_phone, author_role
     creator_info.host_name = platform.node()
     creator_info.location = location
     creator_info.comment = comment
-    if author_name is not None:
+    if author_name is not None or author_email is not None or author_role is not None or author_phone is not None:
         author_object = MHLAuthor(author_name, author_email, author_phone, author_role)
         creator_info.authors.append(author_object)
 

--- a/ascmhl/hashlist_xml_parser.py
+++ b/ascmhl/hashlist_xml_parser.py
@@ -360,7 +360,15 @@ def _creator_info_xml_element(hash_list: MHLHashList):
         E.tool(creator_info.tool.name, version=creator_info.tool.version),
     )
     for author in creator_info.authors:
-        author_element = E.author(author.name, role=author.role, email=author.email, phone=author.phone)
+        author_element = E.author()
+        if author.role != None:
+            author_element.attrib['role'] = author.role
+        if author.email != None:
+            author_element.attrib['email'] = author.email
+        if author.phone != None:
+            author_element.attrib['phone'] = author.phone
+        if author.name != None and author.name != "-":
+            author_element.text = author.name
         info_element.append(author_element)
 
     if creator_info.location is not None:

--- a/ascmhl/hashlist_xml_parser.py
+++ b/ascmhl/hashlist_xml_parser.py
@@ -109,6 +109,17 @@ def parse(file_path):
                         current_object = None
 
                     # author
+                    elif tag == "author":
+                        if current_object.authors[-1].name == "-":
+                            current_object.authors[-1].name = element.text
+                        if current_object.authors[-1].role == None:
+                            current_object.authors[-1].role = element.attrib.get("role")
+                        if current_object.authors[-1].email == None:
+                            current_object.authors[-1].email = element.attrib.get("email")
+                        if current_object.authors[-1].phone == None:
+                            current_object.authors[-1].phone = element.attrib.get("phone")
+
+                    # author (not as spec says, only here for backwards compatibility)
                     elif tag == "name":
                         current_object.authors[-1].name = element.text
                     elif tag == "role":
@@ -355,15 +366,7 @@ def _creator_info_xml_element(hash_list: MHLHashList):
         info_element.append(E.comment(creator_info.comment))
 
     for author in creator_info.authors:
-        author_element = E.author()
-        if author.name is not None:
-            author_element.append(E.name(author.name))
-        if author.role is not None:
-            author_element.append(E.role(author.role))
-        if author.email is not None:
-            author_element.append(E.email(author.email))
-        if author.phone is not None:
-            author_element.append(E.phone(author.phone))
+        author_element = E.author(author.name, role=author.role, email=author.email, phone=author.phone)
         info_element.append(author_element)
 
     return info_element

--- a/ascmhl/hashlist_xml_parser.py
+++ b/ascmhl/hashlist_xml_parser.py
@@ -359,15 +359,15 @@ def _creator_info_xml_element(hash_list: MHLHashList):
         E.hostname(creator_info.host_name),
         E.tool(creator_info.tool.name, version=creator_info.tool.version),
     )
+    for author in creator_info.authors:
+        author_element = E.author(author.name, role=author.role, email=author.email, phone=author.phone)
+        info_element.append(author_element)
+
     if creator_info.location is not None:
         info_element.append(E.location(creator_info.location))
 
     if creator_info.comment is not None:
         info_element.append(E.comment(creator_info.comment))
-
-    for author in creator_info.authors:
-        author_element = E.author(author.name, role=author.role, email=author.email, phone=author.phone)
-        info_element.append(author_element)
 
     return info_element
 

--- a/ascmhl/hashlist_xml_parser.py
+++ b/ascmhl/hashlist_xml_parser.py
@@ -362,11 +362,11 @@ def _creator_info_xml_element(hash_list: MHLHashList):
     for author in creator_info.authors:
         author_element = E.author()
         if author.role != None:
-            author_element.attrib['role'] = author.role
+            author_element.attrib["role"] = author.role
         if author.email != None:
-            author_element.attrib['email'] = author.email
+            author_element.attrib["email"] = author.email
         if author.phone != None:
-            author_element.attrib['phone'] = author.phone
+            author_element.attrib["phone"] = author.phone
         if author.name != None and author.name != "-":
             author_element.text = author.name
         info_element.append(author_element)


### PR DESCRIPTION
Currently the `ascmhl create` command writes wrong syntax for author info (as part of `<creatorinfo>` tag):

```
    <author>
      <name>John Doe</name>
      <role>Data wrangler</role>
      <email>john@mail.com</email>
      <phone>+1 123 456789</phone>
    </author>
```

Changed to updated syntax:

```
    <author role="Data wrangler" email="john@mail.com" phone="+1 123 456789">John Doe</author>
```

Please not that backwards compatibility is maintained in the `ascmhl` commands, so ASC MHL histories with the wrong/old syntax above can still be read. This avoids that any previously written histories get unusable.

Also the order of tags within the `<creatorinfo>` is fixed to conform to the XSD.