### PR TITLE
Improving robustness for uppercase hashes in manifest files

### DIFF
--- a/ascmhl/hashlist_xml_parser.py
+++ b/ascmhl/hashlist_xml_parser.py
@@ -164,9 +164,14 @@ def parse(file_path):
                             else:
                                 # find right hash entry and set structure hash
                                 entry = current_object.find_hash_entry_for_format(tag)
-                                entry.structure_hash_string = element.text
+                                entry.structure_hash_string = (
+                                    element.text.lower()
+                                )  # lower() for improved robustness for uppercase hashes in manifests (which is actually covered in the spec unambiguously)
+
                         else:
-                            entry = MHLHashEntry(tag, element.text, element.attrib.get("action"), hash_date)
+                            entry = MHLHashEntry(
+                                tag, element.text.lower(), element.attrib.get("action"), hash_date
+                            )  # lower() for improved robustness for uppercase hashes in manifests (which is actually covered in the spec unambiguously)
                             current_object.append_hash_entry(entry)
 
                     elif tag == "hash" or tag == "directoryhash":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-experimental-string-processing = true
+# experimental-string-processing = true


### PR DESCRIPTION
Pull requests improves robustness for ASC MHL manifests with hashes in wrong casing (i.e. uppercase hashes).