### PR TITLE
Handle Windows paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/build
 docs/docenv
 .coverage
 htmlcov
+.vscode/launch.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/ascmhl/chain_xml_parser.py
+++ b/ascmhl/chain_xml_parser.py
@@ -20,6 +20,7 @@ from lxml.builder import E
 from .hashlist import *
 from .__version__ import ascmhl_supported_hashformats
 from .hashlist import MHLHashList
+from .paths import _convert_local_to_xml_path, _convert_xml_to_local_path
 
 
 def parse(file_path):
@@ -51,7 +52,7 @@ def parse(file_path):
 
                 if type(current_object) is MHLChainGeneration:
                     if tag == "path":
-                        current_object.ascmhl_filename = element.text
+                        current_object.ascmhl_filename = _convert_xml_to_local_path(element.text)
                     elif tag in ascmhl_supported_hashformats:
                         current_object.hash_format = tag
                         current_object.hash_string = element.text
@@ -102,7 +103,7 @@ def _hashlist_xml_element_from_hashlist(hash_list: MHLHashList):
     """builds and returns one <hashlist> element for a given HashList object"""
 
     hash_list_element = E.hashlist(
-        E.path(os.path.basename(hash_list.file_path)),
+        E.path(_convert_local_to_xml_path(os.path.basename(hash_list.file_path))),
         E.c4(hash_list.generate_reference_hash()),
     )
     hash_list_element.attrib["sequencenr"] = str(hash_list.generation_number)
@@ -115,7 +116,7 @@ def _hashlist_xml_element_from_chaingeneration(generation: MHLChainGeneration):
 
     if generation.hash_format == "c4":
         hash_list_element = E.hashlist(
-            E.path(generation.ascmhl_filename),
+            E.path(_convert_local_to_xml_path(generation.ascmhl_filename)),
             E.c4(generation.hash_string),
         )
         hash_list_element.attrib["sequencenr"] = str(generation.generation_number)

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -13,6 +13,7 @@ import platform
 
 import click
 from lxml import etree
+from pathlib import Path
 
 from . import logger
 from . import errors
@@ -1504,7 +1505,7 @@ def test_for_missing_files(not_found_paths, root_path, ignore_spec: MHLIgnoreSpe
     # test our not_found_paths against our ignore spec to ensure these weren't explicitly ignored.
     logger.error(f"ERROR: {len(not_found_paths)} missing file(s):")
     for path in not_found_paths:
-        logger.error(f"  {os.path.relpath(path, root_path)}")
+        logger.error(f"  {Path(os.path.relpath(path, root_path)).as_posix()}")
     return errors.CompletenessCheckFailedException()
 
 

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -232,7 +232,7 @@ def create_for_folder_subcommand(
 
     # we collect all paths we expect to find first and remove every path that we actually found while
     # traversing the file system, so this set will at the end contain the file paths not found in the file system
-    not_found_paths = existing_history.set_of_file_paths()
+    not_found_paths = existing_history.set_of_file_paths(potential_windows_paths=convert_windows_paths)
     renamed_files = existing_history.renamed_path_with_previous_path()
     not_found_paths = {p if renamed_files.get(p, None) is None else renamed_files[p] for p in not_found_paths}
     new_paths = set()

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -640,7 +640,7 @@ def verify_entire_folder(
     if single_file is not None and not os.path.isabs(single_file):
         single_file = os.path.join(root_path, single_file)
 
-    logger.verbose(f"check folder at path: {root_path}")
+    logger.verbose(f"check folder at path: {Path(root_path).as_posix()}")
 
     if packing_list_path is not None:
         existing_history = MHLHistory.load_from_packing_list_path(packing_list_path, root_path)
@@ -686,17 +686,17 @@ def verify_entire_folder(
 
                 # in case there is no original hash entry continue
                 if original_hash_entry is None:
-                    logger.error(f"found new file {relative_path}")
+                    logger.error(f"found new file {Path(relative_path).as_posix()}")
                     num_new_files += 1
                     continue
 
                 # create a new hash and compare it against the original hash entry
                 current_hash = hash_file(file_path, original_hash_entry.hash_format)
                 if original_hash_entry.hash_string == current_hash:
-                    logger.verbose(f"verification ({original_hash_entry.hash_format}) of file {relative_path}: OK")
+                    logger.verbose(f"verification ({original_hash_entry.hash_format}) of file {Path(relative_path).as_posix()}: OK")
                 else:
                     logger.error(
-                        f"ERROR: hash mismatch        for {relative_path} "
+                        f"ERROR: hash mismatch        for {Path(relative_path).as_posix()} "
                         f"old {original_hash_entry.hash_format}: {original_hash_entry.hash_string}, "
                         f"new {original_hash_entry.hash_format}: {current_hash}"
                     )
@@ -742,7 +742,7 @@ def verify_directory_hash_subcommand(
     if not os.path.isabs(root_path):
         root_path = os.path.join(os.getcwd(), root_path)
 
-    logger.verbose(f"check folder at path: {root_path}")
+    logger.verbose(f"check folder at path: {Path(root_path).as_posix()}")
 
     existing_history = MHLHistory.load_from_path(root_path, potential_windows_paths=convert_windows_paths)
 
@@ -1078,7 +1078,7 @@ def diff_entire_folder_against_full_history_subcommand(
     if not os.path.isabs(root_path):
         root_path = os.path.join(os.getcwd(), root_path)
 
-    logger.verbose(f"check folder at path: {root_path}")
+    logger.verbose(f"check folder at path: {Path(root_path).as_posix()}")
 
     existing_history = MHLHistory.load_from_path(root_path, potential_windows_paths=convert_windows_paths)
 
@@ -1395,7 +1395,7 @@ def log_child_histories(history):
             logger.info(f"  Generation {hash_list.generation_number} ({hash_list.creator_info.creation_date})")
 
     for child_history in history.child_histories:
-        logger.info(f"\nChild History at {child_history.get_root_path()}:")
+        logger.info(f"\nChild History at {Path(child_history.get_root_path()).as_posix()}:")
         log_child_histories(child_history)
 
 
@@ -1409,7 +1409,7 @@ def info_for_single_file(root_path, verbose, single_file, convert_windows_paths=
     if not os.path.isabs(root_path):
         root_path = os.path.join(os.getcwd(), root_path)
 
-    logger.info(f"Info with history at path: {root_path}")
+    logger.info(f"Info with history at path: {Path(root_path).as_posix()}")
 
     existing_history = MHLHistory.load_from_path(root_path, potential_windows_paths=convert_windows_paths)
 

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -1347,7 +1347,7 @@ def info(verbose, single_file, root_path, convert_windows_paths):
     if single_file is not None and len(single_file) > 0:
         if root_path == None:
             current_dir = os.path.dirname(os.path.abspath(single_file[0]))
-            while current_dir != "/" and current_dir != "":
+            while current_dir != "/" and current_dir != "" and (len(current_dir)>4 and current_dir[1:4] != ":\\\\"):
                 asc_mhl_folder_path = os.path.join(current_dir, ascmhl_folder_name)
                 if os.path.exists(asc_mhl_folder_path):
                     root_path = current_dir
@@ -1373,7 +1373,8 @@ def info_for_entire_history(root_path, verbose, convert_windows_paths=False):
     if not os.path.isabs(root_path):
         root_path = os.path.join(os.getcwd(), root_path)
 
-    logger.info(f"Info with history at path: {root_path}")
+    _, tail = os.path.splitdrive(root_path)
+    logger.info(f"Info with history at path: {Path(tail).as_posix()}")
 
     existing_history = MHLHistory.load_from_path(root_path, potential_windows_paths=convert_windows_paths)
 
@@ -1411,7 +1412,8 @@ def info_for_single_file(root_path, verbose, single_file, convert_windows_paths=
     if not os.path.isabs(root_path):
         root_path = os.path.join(os.getcwd(), root_path)
 
-    logger.info(f"Info with history at path: {Path(root_path).as_posix()}")
+    _, tail = os.path.splitdrive(root_path)
+    logger.info(f"Info with history at path: {Path(tail).as_posix()}")
 
     existing_history = MHLHistory.load_from_path(root_path, potential_windows_paths=convert_windows_paths)
 

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -652,7 +652,7 @@ def verify_entire_folder(
 
     # we collect all paths we expect to find first and remove every path that we actually found while
     # traversing the file system, so this set will at the end contain the file paths not found in the file system
-    not_found_paths = existing_history.set_of_file_paths()
+    not_found_paths = existing_history.set_of_file_paths(potential_windows_paths=convert_windows_paths)
     renamed_files = existing_history.renamed_path_with_previous_path()
     not_found_paths = {p if renamed_files.get(p, None) is None else renamed_files[p] for p in not_found_paths}
 
@@ -1089,7 +1089,7 @@ def diff_entire_folder_against_full_history_subcommand(
 
     # we collect all paths we expect to find first and remove every path that we actually found while
     # traversing the file system, so this set will at the end contain the file paths not found in the file system
-    not_found_paths = existing_history.set_of_file_paths()
+    not_found_paths = existing_history.set_of_file_paths(potential_windows_paths=convert_windows_paths)
     renamed_files = existing_history.renamed_path_with_previous_path()
     not_found_paths = {p if renamed_files.get(p, None) is None else renamed_files[p] for p in not_found_paths}
 

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -1347,7 +1347,7 @@ def info(verbose, single_file, root_path, convert_windows_paths):
     if single_file is not None and len(single_file) > 0:
         if root_path == None:
             current_dir = os.path.dirname(os.path.abspath(single_file[0]))
-            while current_dir != "/" and current_dir != "" and (len(current_dir)>4 and current_dir[1:4] != ":\\\\"):
+            while current_dir != "/" and current_dir != "" and (len(current_dir) > 4 and current_dir[1:4] != ":\\\\"):
                 asc_mhl_folder_path = os.path.join(current_dir, ascmhl_folder_name)
                 if os.path.exists(asc_mhl_folder_path):
                     root_path = current_dir

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -693,7 +693,9 @@ def verify_entire_folder(
                 # create a new hash and compare it against the original hash entry
                 current_hash = hash_file(file_path, original_hash_entry.hash_format)
                 if original_hash_entry.hash_string == current_hash:
-                    logger.verbose(f"verification ({original_hash_entry.hash_format}) of file {Path(relative_path).as_posix()}: OK")
+                    logger.verbose(
+                        f"verification ({original_hash_entry.hash_format}) of file {Path(relative_path).as_posix()}: OK"
+                    )
                 else:
                     logger.error(
                         f"ERROR: hash mismatch        for {Path(relative_path).as_posix()} "

--- a/ascmhl/generator.py
+++ b/ascmhl/generator.py
@@ -74,13 +74,17 @@ class MHLGenerationCreationSession:
             hash_entry = MHLHashEntry(hash_format, hash_string, hash_date=hash_date)
             if original_hash_entry is None:
                 hash_entry.action = "original"
-                logger.verbose(f"  created original hash for     {Path(relative_path).as_posix()}  {hash_format}: {hash_string}")
+                logger.verbose(
+                    f"  created original hash for     {Path(relative_path).as_posix()}  {hash_format}: {hash_string}"
+                )
             else:
                 existing_hash_entry = history.find_first_hash_entry_for_path(history_relative_path, hash_format)
                 if existing_hash_entry is not None:
                     if existing_hash_entry.hash_string == hash_string:
                         hash_entry.action = "verified"
-                        logger.verbose(f"  verified                      {Path(relative_path).as_posix()} {hash_format}: OK")
+                        logger.verbose(
+                            f"  verified                      {Path(relative_path).as_posix()} {hash_format}: OK"
+                        )
                     else:
                         hash_entry.action = "failed"
                         failures += 1
@@ -94,7 +98,9 @@ class MHLGenerationCreationSession:
                     hash_entry.action = (  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
                         "new"
                     )
-                    logger.verbose(f"  created new (verif.) hash for {Path(relative_path).as_posix()}  {hash_format}: {hash_string}")
+                    logger.verbose(
+                        f"  created new (verif.) hash for {Path(relative_path).as_posix()}  {hash_format}: {hash_string}"
+                    )
             # collection behavior: overwrite action with action from flattened history
             if action != None:
                 hash_entry.action = action
@@ -132,13 +138,17 @@ class MHLGenerationCreationSession:
         hash_entry = MHLHashEntry(hash_format, hash_string, hash_date=hash_date)
         if original_hash_entry is None:
             hash_entry.action = "original"
-            logger.verbose(f"  created original hash for     {Path(relative_path).as_posix()}  {hash_format}: {hash_string}")
+            logger.verbose(
+                f"  created original hash for     {Path(relative_path).as_posix()}  {hash_format}: {hash_string}"
+            )
         else:
             existing_hash_entry = history.find_first_hash_entry_for_path(history_relative_path, hash_format)
             if existing_hash_entry is not None:
                 if existing_hash_entry.hash_string == hash_string:
                     hash_entry.action = "verified"
-                    logger.verbose(f"  verified                      {Path(relative_path).as_posix()}  {hash_format}: OK")
+                    logger.verbose(
+                        f"  verified                      {Path(relative_path).as_posix()}  {hash_format}: OK"
+                    )
                 else:
                     hash_entry.action = "failed"
                     logger.error(
@@ -149,7 +159,9 @@ class MHLGenerationCreationSession:
             else:
                 # in case there is no hash entry for this hash format yet
                 hash_entry.action = "new"  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
-                logger.verbose(f"  created new (verif.) hash for {Path(relative_path).as_posix()}  {hash_format}: {hash_string}")
+                logger.verbose(
+                    f"  created new (verif.) hash for {Path(relative_path).as_posix()}  {hash_format}: {hash_string}"
+                )
 
         # in case the same file is hashes multiple times we want to add all hash entries
         new_hash_list = self.new_hash_lists[history]

--- a/ascmhl/generator.py
+++ b/ascmhl/generator.py
@@ -138,9 +138,10 @@ class MHLGenerationCreationSession:
         hash_entry = MHLHashEntry(hash_format, hash_string, hash_date=hash_date)
         if original_hash_entry is None:
             hash_entry.action = "original"
-            logger.verbose(
-                f"  created original hash for     {Path(relative_path).as_posix()}  {hash_format}: {hash_string}"
-            )
+            if relative_path != None:
+                logger.verbose(
+                    f"  created original hash for     {Path(relative_path).as_posix()}  {hash_format}: {hash_string}"
+                )
         else:
             existing_hash_entry = history.find_first_hash_entry_for_path(history_relative_path, hash_format)
             if existing_hash_entry is not None:

--- a/ascmhl/generator.py
+++ b/ascmhl/generator.py
@@ -9,6 +9,7 @@ __email__ = "opensource@pomfort.com"
 
 from collections import defaultdict
 from typing import Dict, List
+from pathlib import Path
 
 from . import chain_xml_parser
 from . import logger
@@ -73,18 +74,18 @@ class MHLGenerationCreationSession:
             hash_entry = MHLHashEntry(hash_format, hash_string, hash_date=hash_date)
             if original_hash_entry is None:
                 hash_entry.action = "original"
-                logger.verbose(f"  created original hash for     {relative_path}  {hash_format}: {hash_string}")
+                logger.verbose(f"  created original hash for     {Path(relative_path).as_posix()}  {hash_format}: {hash_string}")
             else:
                 existing_hash_entry = history.find_first_hash_entry_for_path(history_relative_path, hash_format)
                 if existing_hash_entry is not None:
                     if existing_hash_entry.hash_string == hash_string:
                         hash_entry.action = "verified"
-                        logger.verbose(f"  verified                      {relative_path} {hash_format}: OK")
+                        logger.verbose(f"  verified                      {Path(relative_path).as_posix()} {hash_format}: OK")
                     else:
                         hash_entry.action = "failed"
                         failures += 1
                         logger.error(
-                            f"ERROR: hash mismatch for        {relative_path}  "
+                            f"ERROR: hash mismatch for        {Path(relative_path).as_posix()}  "
                             f"{hash_format} (old): {existing_hash_entry.hash_string}, "
                             f"{hash_format} (new): {hash_string}"
                         )
@@ -93,7 +94,7 @@ class MHLGenerationCreationSession:
                     hash_entry.action = (  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
                         "new"
                     )
-                    logger.verbose(f"  created new (verif.) hash for {relative_path}  {hash_format}: {hash_string}")
+                    logger.verbose(f"  created new (verif.) hash for {Path(relative_path).as_posix()}  {hash_format}: {hash_string}")
             # collection behavior: overwrite action with action from flattened history
             if action != None:
                 hash_entry.action = action
@@ -131,24 +132,24 @@ class MHLGenerationCreationSession:
         hash_entry = MHLHashEntry(hash_format, hash_string, hash_date=hash_date)
         if original_hash_entry is None:
             hash_entry.action = "original"
-            logger.verbose(f"  created original hash for     {relative_path}  {hash_format}: {hash_string}")
+            logger.verbose(f"  created original hash for     {Path(relative_path).as_posix()}  {hash_format}: {hash_string}")
         else:
             existing_hash_entry = history.find_first_hash_entry_for_path(history_relative_path, hash_format)
             if existing_hash_entry is not None:
                 if existing_hash_entry.hash_string == hash_string:
                     hash_entry.action = "verified"
-                    logger.verbose(f"  verified                      {relative_path}  {hash_format}: OK")
+                    logger.verbose(f"  verified                      {Path(relative_path).as_posix()}  {hash_format}: OK")
                 else:
                     hash_entry.action = "failed"
                     logger.error(
-                        f"ERROR: hash mismatch for        {relative_path}  "
+                        f"ERROR: hash mismatch for        {Path(relative_path).as_posix()}  "
                         f"{hash_format} (old): {existing_hash_entry.hash_string}, "
                         f"{hash_format} (new): {hash_string}"
                     )
             else:
                 # in case there is no hash entry for this hash format yet
                 hash_entry.action = "new"  # mark as 'new' here, will be changed to verified in _validate_new_hash_list
-                logger.verbose(f"  created new (verif.) hash for {relative_path}  {hash_format}: {hash_string}")
+                logger.verbose(f"  created new (verif.) hash for {Path(relative_path).as_posix()}  {hash_format}: {hash_string}")
 
         # in case the same file is hashes multiple times we want to add all hash entries
         new_hash_list = self.new_hash_lists[history]
@@ -203,12 +204,12 @@ class MHLGenerationCreationSession:
                     )
                 else:
                     logger.verbose(
-                        f"  calculated directory hash for {relative_path}  {hash_format}: "
+                        f"  calculated directory hash for {Path(relative_path).as_posix()}  {hash_format}: "
                         f"{content_hash_string} (content), "
                         f"{structure_hash_string} (structure)"
                     )
         else:
-            logger.verbose(f"  added directory entry for     {relative_path}")
+            logger.verbose(f"  added directory entry for     {Path(relative_path).as_posix()}")
 
         # in case we just created the root media hash of the current hash list we also add it one history level above
         if new_hash_list.process_info.root_media_hash is media_hash and history.parent_history:
@@ -302,7 +303,7 @@ class MHLGenerationCreationSession:
 
             history.write_new_generation(new_hash_list)
             relative_generation_path = self.root_history.get_relative_file_path(new_hash_list.file_path)
-            logger.verbose(f"Created new generation {relative_generation_path}")
+            logger.verbose(f"Created new generation {Path(relative_generation_path).as_posix()}")
             if history.parent_history is not None:
                 referenced_hash_lists[history.parent_history].append(new_hash_list)
 

--- a/ascmhl/hashlist.py
+++ b/ascmhl/hashlist.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import List, Dict, Optional, Set
 from datetime import datetime
 import os
+from pathlib import Path
 
 from . import logger
 from .ignore import MHLIgnoreSpec
@@ -76,10 +77,13 @@ class MHLHashList:
             self.append_hash(media_hash)
         return media_hash
 
-    def set_of_file_paths(self, root_path) -> Set[str]:
+    def set_of_file_paths(self, root_path, potential_windows_paths=False) -> Set[str]:
         all_paths = set()
         for media_hash in self.media_hashes:
-            all_paths.add(os.path.join(root_path, media_hash.path))
+            media_path = media_hash.path
+            if potential_windows_paths:
+                media_path = Path(media_path).as_posix()
+            all_paths.add(os.path.join(root_path, media_path))
         return all_paths
 
     def renamed_path_with_previous_path(self, root_path):

--- a/ascmhl/hashlist_xml_parser.py
+++ b/ascmhl/hashlist_xml_parser.py
@@ -351,7 +351,7 @@ def _ascmhlreference_xml_element(hash_list: MHLHashList, file_path: str):
 
     root_path = os.path.dirname(os.path.dirname(file_path))
     hash_element = E.hashlistreference(
-        E.path(os.path.relpath(hash_list.file_path, root_path)),
+        E.path(_convert_local_to_xml_path(os.path.relpath(hash_list.file_path, root_path))),
         E.c4(hash_list.generate_reference_hash()),
     )
 

--- a/ascmhl/hashlist_xml_parser.py
+++ b/ascmhl/hashlist_xml_parser.py
@@ -162,7 +162,14 @@ def parse(file_path, potential_windows_paths=False):
                             hash_date = dateutil.parser.parse(hash_date_string)
                         if current_object.is_directory:
                             if is_directory_structure == False:
-                                entry = MHLHashEntry(tag, element.text, element.attrib.get("action"), hash_date)
+                                entry = MHLHashEntry(
+                                    tag,
+                                    _convert_xml_to_local_path(
+                                        element.text, convert_from_windows_paths=potential_windows_paths
+                                    ),
+                                    element.attrib.get("action"),
+                                    hash_date,
+                                )
                                 current_object.append_hash_entry(entry)
                             else:
                                 # find right hash entry and set structure hash

--- a/ascmhl/hashlist_xml_parser.py
+++ b/ascmhl/hashlist_xml_parser.py
@@ -30,9 +30,10 @@ from .hashlist import (
 )
 from .ignore import MHLIgnoreSpec
 from .utils import datetime_isostring
+from .paths import _convert_local_to_xml_path, _convert_xml_to_local_path
 
 
-def parse(file_path):
+def parse(file_path, potential_windows_paths=False):
     """parsing the MHL XML file and building the MHLHashList for the hash_list member variable"""
     logger.debug(f"parsing {file_path}...")
 
@@ -146,7 +147,9 @@ def parse(file_path):
 
                 elif type(current_object) is MHLMediaHash:
                     if tag == "path":
-                        current_object.path = element.text
+                        current_object.path = _convert_xml_to_local_path(
+                            element.text, convert_from_windows_paths=potential_windows_paths
+                        )
                         file_size = element.attrib.get("size")
                         current_object.file_size = int(file_size) if file_size else None
                     # TODO: parse date
@@ -182,11 +185,15 @@ def parse(file_path):
                         current_object.root_media_hash = root_media_hash
 
                     elif tag == "previousPath":
-                        current_object.previous_path = element.text
+                        current_object.previous_path = _convert_xml_to_local_path(
+                            element.text, convert_from_windows_paths=potential_windows_paths
+                        )
 
                 elif type(current_object) is MHLHashListReference:
                     if tag == "path":
-                        current_object.path = element.text
+                        current_object.path = _convert_xml_to_local_path(
+                            element.text, convert_from_windows_paths=potential_windows_paths
+                        )
                     elif tag == "c4":
                         current_object.reference_hash = element.text
                     elif tag == "hashlistreference":
@@ -270,7 +277,7 @@ def _write_xml_string_to_file(file, xml_string: str, indent: str):
 def _media_hash_xml_element(media_hash: MHLMediaHash):
     """builds and returns one <hash> element for a given MediaHash object"""
 
-    path_element = E.path(media_hash.path)
+    path_element = E.path(_convert_local_to_xml_path(media_hash.path))
     if media_hash.file_size:
         path_element.attrib["size"] = str(media_hash.file_size)
     if media_hash.last_modification_date:
@@ -288,8 +295,8 @@ def _media_hash_xml_element(media_hash: MHLMediaHash):
         hash_element.append(entry_element)
 
     if media_hash.previous_path:
-        previous_path_element = E.previousPath(media_hash.previous_path)
-        previous_path_element.text = media_hash.previous_path
+        previous_path_element = E.previousPath(_convert_local_to_xml_path(media_hash.previous_path))
+        previous_path_element.text = _convert_local_to_xml_path(media_hash.previous_path)
         hash_element.append(previous_path_element)
 
     return hash_element
@@ -321,7 +328,7 @@ def _directory_hash_xml_element(media_hash: MHLMediaHash, skipPath=False):
     hash_element = E.directoryhash()
 
     if skipPath == False:
-        path_element = E.path(media_hash.path)
+        path_element = E.path(_convert_local_to_xml_path(media_hash.path))
         if media_hash.file_size:
             path_element.attrib["size"] = str(media_hash.file_size)
         if media_hash.last_modification_date:
@@ -332,8 +339,8 @@ def _directory_hash_xml_element(media_hash: MHLMediaHash, skipPath=False):
     hash_element.append(structure_element)
 
     if media_hash.previous_path:
-        previous_path_element = E.previousPath(media_hash.previous_path)
-        previous_path_element.text = media_hash.previous_path
+        previous_path_element = E.previousPath(_convert_local_to_xml_path(media_hash.previous_path))
+        previous_path_element.text = _convert_local_to_xml_path(media_hash.previous_path)
         hash_element.append(previous_path_element)
 
     return hash_element

--- a/ascmhl/history.py
+++ b/ascmhl/history.py
@@ -260,7 +260,9 @@ class MHLHistory:
                                 hash_entry.temp_generation_number = hash_list.generation_number
                         hash_lists.append(hash_list)
                     else:
-                        logger.error(f"name of ascmhl file {filename} does not conform to naming convention")
+                        logger.error(
+                            f"name of ascmhl file {Path(filename).as_posix()} does not conform to naming convention"
+                        )
         # sort all found hash lists by generation number first to make sure we add them to the history in order
         hash_lists.sort(key=lambda x: x.generation_number)
         for hash_list in hash_lists:

--- a/ascmhl/history.py
+++ b/ascmhl/history.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import re
 from datetime import datetime, date, time
+from pathlib import Path
 
 from . import hasher
 from .__version__ import ascmhl_folder_name, ascmhl_file_extension, ascmhl_chainfile_name, ascmhl_collectionfile_name
@@ -240,7 +241,9 @@ class MHLHistory:
         hash_lists = []
         for root, directories, filenames in os.walk(asc_mhl_folder_path):
             for filename in filenames:
-                if filename.endswith(ascmhl_file_extension):
+                if (len(filename) > 2 and filename[:2] != "._") and filename.endswith(
+                    ascmhl_file_extension
+                ):  # ignore ._ variants of mhl files that can happen when moving data from macOS to Windows and back
                     # file name example: 0001_root_2020-01-15_130000.mhl
                     filename_no_extension, _ = os.path.splitext(filename)
                     parts = re.findall(MHLHistory.history_file_name_regex, filename_no_extension)

--- a/ascmhl/history.py
+++ b/ascmhl/history.py
@@ -268,7 +268,7 @@ class MHLHistory:
         for hash_list in hash_lists:
             history.append_hash_list(hash_list)
 
-        history._find_and_load_child_histories()
+        history._find_and_load_child_histories(potential_windows_paths=potential_windows_paths)
 
         return history
 
@@ -311,14 +311,14 @@ class MHLHistory:
 
         return history
 
-    def _find_and_load_child_histories(self) -> None:
+    def _find_and_load_child_histories(self, potential_windows_paths) -> None:
         """traverses the whole file system tree inside the history to find all sub histories"""
         history_root = self.get_root_path()
         for root, directories, _ in os.walk(history_root):
             if root != history_root and ascmhl_folder_name in directories:
                 # we parse the mhl folder and clear the directories so we are not going deeper
                 # everything beneath is handled by the child history
-                child_history = MHLHistory.load_from_path(root)
+                child_history = MHLHistory.load_from_path(root, potential_windows_paths=potential_windows_paths)
                 child_history.parent_history = self
                 self.append_child_history(child_history)
                 directories.clear()

--- a/ascmhl/history.py
+++ b/ascmhl/history.py
@@ -194,7 +194,6 @@ class MHLHistory:
             all_paths.update(hash_list.set_of_file_paths(self.get_root_path()))
         for child_history in self.child_histories:
             all_paths.update(child_history.set_of_file_paths())
-
         return all_paths
 
     def renamed_path_with_previous_path(self):
@@ -217,7 +216,7 @@ class MHLHistory:
     # loading history and child histories from path
 
     @classmethod
-    def load_from_path(cls, root_path):
+    def load_from_path(cls, root_path, potential_windows_paths=False):
         """finds all MHL files in the asc-mhl folder, returns the mhl_history instance with all mhl_hashlists"""
 
         asc_mhl_folder_path = os.path.join(root_path, ascmhl_folder_name)
@@ -247,7 +246,9 @@ class MHLHistory:
                     parts = re.findall(MHLHistory.history_file_name_regex, filename_no_extension)
                     if len(parts) == 1 and len(parts[0]) == 2:
                         file_path = os.path.join(asc_mhl_folder_path, filename)
-                        hash_list = hashlist_xml_parser.parse(file_path)
+                        hash_list = hashlist_xml_parser.parse(
+                            file_path, potential_windows_paths=potential_windows_paths
+                        )
                         generation_number = int(parts[0][0])
                         hash_list.generation_number = generation_number
                         # FIXME is there a better way of accessing the generation from a hash entry?
@@ -267,7 +268,7 @@ class MHLHistory:
         return history
 
     @classmethod
-    def load_from_packing_list_path(cls, packing_list_path, root_path):
+    def load_from_packing_list_path(cls, packing_list_path, root_path, potential_windows_paths=False):
         """returns the mhl_history instance with the one packing list mhl_hashlists"""
         # via https://docs.google.com/document/d/1FVSyHq2XJdNt-3Vur_5I_FPOoeeC_cEjkv7p---biyg/edit#
 
@@ -275,7 +276,7 @@ class MHLHistory:
         history = cls()
         history.asc_mhl_path = asc_mhl_folder_path
 
-        hash_list = hashlist_xml_parser.parse(packing_list_path)
+        hash_list = hashlist_xml_parser.parse(packing_list_path, potential_windows_paths=potential_windows_paths)
         hash_list.generation_number = 1
         history.append_hash_list(hash_list)
 

--- a/ascmhl/history.py
+++ b/ascmhl/history.py
@@ -189,10 +189,12 @@ class MHLHistory:
             dir_path = os.path.dirname(dir_path)
         return self, relative_path
 
-    def set_of_file_paths(self) -> Set[str]:
+    def set_of_file_paths(self, potential_windows_paths=False) -> Set[str]:
         all_paths = set()
         for hash_list in self.hash_lists:
-            all_paths.update(hash_list.set_of_file_paths(self.get_root_path()))
+            all_paths.update(
+                hash_list.set_of_file_paths(self.get_root_path(), potential_windows_paths=potential_windows_paths)
+            )
         for child_history in self.child_histories:
             all_paths.update(child_history.set_of_file_paths())
         return all_paths

--- a/ascmhl/paths.py
+++ b/ascmhl/paths.py
@@ -58,7 +58,7 @@ def _convert_xml_to_local_path(path: str, convert_from_windows_paths=False) -> s
         if os.name == "posix":
             return path
         elif os.name == "nt":
-            return str(PureWindowsPath(PurePosixPath(posix_path)))
+            return str(PureWindowsPath(PurePosixPath(path)))
         else:
             print(f"ERR: Unknown operating system: {os.name}")
             assert 0

--- a/ascmhl/paths.py
+++ b/ascmhl/paths.py
@@ -1,0 +1,76 @@
+from enum import Enum
+from pathlib import Path, PurePosixPath, PureWindowsPath
+import os
+
+
+class _PathType(Enum):
+    UNKNOWN = "unknown"
+    WINDOWS = "windows"
+    POSIX = "posix"
+    MIXED = "mixed"
+
+
+def _detect_path_type(path: str) -> _PathType:
+    windows_delimiters = path.count("\\")
+    posix_delimiters = path.count("/")
+
+    if windows_delimiters > 0 and posix_delimiters > 0:
+        return _PathType.MIXED
+    elif windows_delimiters > 0:
+        return _PathType.WINDOWS
+    elif posix_delimiters > 0:
+        return _PathType.POSIX
+    else:
+        return _PathType.UNKNOWN
+
+
+def _convert_local_to_xml_path(path: str, _xml_path_type=_PathType.POSIX) -> str:
+
+    if _xml_path_type == _PathType.POSIX:
+        return str(Path(path).as_posix())  # anything to posix
+
+    # debug only, is against the ASC MHL specification:
+    elif _xml_path_type == _PathType.WINDOWS:
+        if os.name == "posix":  # posix to windows
+            return str(PureWindowsPath(PurePosixPath(path)))
+        elif os.name == "nt":  # windows to windows
+            return path
+        else:
+            print(f"ERR: Unknown operating system: {os.name}")
+
+    else:
+        raise ValueError(f"ERR: Unsupported path type: {_xml_path_type}")
+
+
+def _convert_xml_to_local_path(path: str, convert_from_windows_paths=False) -> str:
+
+    # detect_windows_path_type: option for robust detection of (wrong) windows xml path
+
+    xml_path_type = _PathType.POSIX
+    if convert_from_windows_paths:
+        xml_path_type = _detect_path_type(path)
+        if xml_path_type == _PathType.MIXED:
+            xml_path_type = _PathType.POSIX  # probably a backslash in a path name?
+        if xml_path_type == _PathType.UNKNOWN:
+            xml_path_type = _PathType.POSIX  # no path delimiters found, so safely assume posix
+
+    if xml_path_type == _PathType.POSIX:
+        if os.name == "posix":
+            return path
+        elif os.name == "nt":
+            return str(PureWindowsPath(PurePosixPath(posix_path)))
+        else:
+            print(f"ERR: Unknown operating system: {os.name}")
+            assert 0
+
+    elif xml_path_type == _PathType.WINDOWS:
+        if os.name == "posix":
+            return PureWindowsPath(path).as_posix()
+        elif os.name == "nt":
+            return path
+        else:
+            print(f"ERR: Unknown operating system: {os.name}")
+            assert 0
+
+    else:
+        raise ValueError(f"ERR: Unsupported path type: {xml_path_type}")

--- a/ascmhl/traverse.py
+++ b/ascmhl/traverse.py
@@ -9,6 +9,7 @@ __email__ = "opensource@jonwaggoner.com"
 
 from os.path import join, isdir
 import os
+from pathlib import Path
 
 from . import logger
 import pathspec
@@ -33,7 +34,7 @@ def post_order_lexicographic(top: str, ignore_pathspec: pathspec.PathSpec = None
         file_path = os.path.join(top, name)
         if ignore_pathspec and ignore_pathspec.match_file(file_path):
             if os.path.basename(os.path.normpath(file_path)) != ascmhl_folder_name:
-                logger.verbose(f"ignoring filepath {file_path}")
+                logger.verbose(f"ignoring filepath {Path(file_path).as_posix()}")
             continue
         path = join(top, name)
         children.append((name, isdir(path)))

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -221,8 +221,10 @@ def test_create_fail_altered_file(fs, simple_mhl_history):
     assert result.exit_code == 11
     assert "Stuff.txt" in result.output
 
+
 def convert_to_posix(path):
     return Path(path).as_posix()
+
 
 def test_create_fail_missing_file(fs, nested_mhl_histories):
     """
@@ -270,7 +272,7 @@ def test_create_fail_missing_file(fs, nested_mhl_histories):
     # since we scan all generations for file paths we now get old files, missing files and new files here
     # as well as all entries for the directories
     assert paths == compare_paths
-    
+
     # since the file /root/A/AA/AA1.txt is still missing all further seal attempts will still fail
     runner = CliRunner()
     result = runner.invoke(ascmhl.commands.create, ["/root"])

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -10,6 +10,7 @@ __email__ = "opensource@pomfort.com"
 import os
 from freezegun import freeze_time
 from click.testing import CliRunner
+from pathlib import Path
 
 from ascmhl.history import MHLHistory
 import ascmhl.commands
@@ -220,6 +221,8 @@ def test_create_fail_altered_file(fs, simple_mhl_history):
     assert result.exit_code == 11
     assert "Stuff.txt" in result.output
 
+def convert_to_posix(path):
+    return Path(path).as_posix()
 
 def test_create_fail_missing_file(fs, nested_mhl_histories):
     """
@@ -228,8 +231,13 @@ def test_create_fail_missing_file(fs, nested_mhl_histories):
 
     root_history = MHLHistory.load_from_path("/root")
     paths = root_history.set_of_file_paths()
+    paths = list(map(convert_to_posix, paths))
+    paths.sort()
 
-    assert paths == {"/root/B/B1.txt", "/root/B/BB/BB1.txt", "/root/Stuff.txt", "/root/A/AA/AA1.txt"}
+    compare_paths = ["/root/B/B1.txt", "/root/B/BB/BB1.txt", "/root/Stuff.txt", "/root/A/AA/AA1.txt"]
+    compare_paths.sort()
+
+    assert paths == compare_paths
     os.remove("/root/A/AA/AA1.txt")
     runner = CliRunner()
     result = runner.invoke(ascmhl.commands.create, ["/root"])
@@ -240,10 +248,10 @@ def test_create_fail_missing_file(fs, nested_mhl_histories):
     # the new not yet referenced files (/root/B/BA/BA1.txt and /root/A/AB/AB1.txt) as well now
     root_history = MHLHistory.load_from_path("/root")
     paths = root_history.set_of_file_paths()
+    paths = list(map(convert_to_posix, paths))
+    paths.sort()
 
-    # since we scan all generations for file paths we now get old files, missing files and new files here
-    # as well as all entries for the directories
-    assert paths == {
+    compare_paths = [
         "/root/B/B1.txt",
         "/root/B/BA/BA1.txt",
         "/root/B",
@@ -256,8 +264,13 @@ def test_create_fail_missing_file(fs, nested_mhl_histories):
         "/root/B/BB",
         "/root/A",
         "/root/B/BB/BB1.txt",
-    }
+    ]
+    compare_paths.sort()
 
+    # since we scan all generations for file paths we now get old files, missing files and new files here
+    # as well as all entries for the directories
+    assert paths == compare_paths
+    
     # since the file /root/A/AA/AA1.txt is still missing all further seal attempts will still fail
     runner = CliRunner()
     result = runner.invoke(ascmhl.commands.create, ["/root"])

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -10,6 +10,7 @@ __email__ = "opensource@pomfort.com"
 import os
 from click.testing import CliRunner
 from freezegun import freeze_time
+from pathlib import Path
 
 import ascmhl
 
@@ -42,10 +43,10 @@ def test_create_nested_succeed(fs):
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
     with open("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl", "r") as fin:
         fileContents = fin.read()
-        assert "0002_AA_2020-01-16_091500Z.mhl" in fileContents
-        assert "B/ascmhl/0002_B_2020-01-16_091500Z.mhl" in fileContents
-        assert "AA1.txt" not in fileContents
-        assert "C1.txt" in fileContents
+        assert str(Path("0002_AA_2020-01-16_091500Z.mhl")) in fileContents
+        assert str(Path("B/ascmhl/0002_B_2020-01-16_091500Z.mhl")) in fileContents
+        assert str(Path("AA1.txt")) not in fileContents
+        assert str(Path("C1.txt")) in fileContents
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
     result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
@@ -55,8 +56,8 @@ def test_create_nested_succeed(fs):
     assert not os.path.exists("/root/ascmhl/0003_B_2020-01-16_091500Z.mhl")
     with open("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl", "r") as fin:
         fileContents = fin.read()
-        assert "0003_AA_2020-01-16_091500Z.mhl" in fileContents
-        assert "AA2.txt" not in fileContents
+        assert str(Path("0003_AA_2020-01-16_091500Z.mhl")) in fileContents
+        assert str(Path("AA2.txt")) not in fileContents
 
     # test history command
     result = runner.invoke(ascmhl.commands.info, ["/root"])
@@ -93,10 +94,10 @@ def test_create_nested_mhl_file_modified(fs):
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
     with open("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl", "r") as fin:
         fileContents = fin.read()
-        assert "0002_AA_2020-01-16_091500Z.mhl" in fileContents
-        assert "B/ascmhl/0002_B_2020-01-16_091500Z.mhl" in fileContents
-        assert "AA1.txt" not in fileContents
-        assert "C1.txt" in fileContents
+        assert str(Path("0002_AA_2020-01-16_091500Z.mhl")) in fileContents
+        assert str(Path("B/ascmhl/0002_B_2020-01-16_091500Z.mhl")) in fileContents
+        assert str(Path("AA1.txt")) not in fileContents
+        assert str(Path("C1.txt")) in fileContents
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
 
@@ -135,14 +136,15 @@ def test_create_nested_mhl_file_missing(fs):
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
     with open("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl", "r") as fin:
         fileContents = fin.read()
-        assert "0002_AA_2020-01-16_091500Z.mhl" in fileContents
-        assert "B/ascmhl/0002_B_2020-01-16_091500Z.mhl" in fileContents
-        assert "AA1.txt" not in fileContents
-        assert "C1.txt" in fileContents
+        assert str(Path("0002_AA_2020-01-16_091500Z.mhl")) in fileContents
+        assert str(Path("B/ascmhl/0002_B_2020-01-16_091500Z.mhl")) in fileContents
+        assert str(Path("AA1.txt")) not in fileContents
+        assert str(Path("C1.txt")) in fileContents
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
-
-    os.remove("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl")
+    remove_file = "C:" + str(Path("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl"))
+    print(f"DBG: remove_file {remove_file}")
+    os.remove(remove_file)
     result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
     assert result.exception
     assert result.exit_code == 33
@@ -180,13 +182,13 @@ def test_create_nested_mhl_chain_missing(fs):
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
     with open("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl", "r") as fin:
         fileContents = fin.read()
-        assert "0002_AA_2020-01-16_091500Z.mhl" in fileContents
-        assert "B/ascmhl/0002_B_2020-01-16_091500Z.mhl" in fileContents
-        assert "AA1.txt" not in fileContents
-        assert "C1.txt" in fileContents
+        assert str(Path("0002_AA_2020-01-16_091500Z.mhl")) in fileContents
+        assert str(Path("B/ascmhl/0002_B_2020-01-16_091500Z.mhl")) in fileContents
+        assert str(Path("AA1.txt")) not in fileContents
+        assert str(Path("C1.txt")) in fileContents
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
-    os.remove("/root/A/AA/ascmhl/ascmhl_chain.xml")
+    os.remove(str(Path("/root/A/AA/ascmhl/ascmhl_chain.xml")))
     result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
     assert result.exception
     assert result.exit_code == 32

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -43,10 +43,10 @@ def test_create_nested_succeed(fs):
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
     with open("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl", "r") as fin:
         fileContents = fin.read()
-        assert str(Path("0002_AA_2020-01-16_091500Z.mhl")) in fileContents
-        assert str(Path("B/ascmhl/0002_B_2020-01-16_091500Z.mhl")) in fileContents
-        assert str(Path("AA1.txt")) not in fileContents
-        assert str(Path("C1.txt")) in fileContents
+        assert "0002_AA_2020-01-16_091500Z.mhl" in fileContents
+        assert "B/ascmhl/0002_B_2020-01-16_091500Z.mhl" in fileContents
+        assert "AA1.txt" not in fileContents
+        assert "C1.txt" in fileContents
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
     result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
@@ -56,8 +56,8 @@ def test_create_nested_succeed(fs):
     assert not os.path.exists("/root/ascmhl/0003_B_2020-01-16_091500Z.mhl")
     with open("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl", "r") as fin:
         fileContents = fin.read()
-        assert str(Path("0003_AA_2020-01-16_091500Z.mhl")) in fileContents
-        assert str(Path("AA2.txt")) not in fileContents
+        assert "0003_AA_2020-01-16_091500Z.mhl" in fileContents
+        assert "AA2.txt" not in fileContents
 
     # test history command
     result = runner.invoke(ascmhl.commands.info, ["/root"])
@@ -94,10 +94,10 @@ def test_create_nested_mhl_file_modified(fs):
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
     with open("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl", "r") as fin:
         fileContents = fin.read()
-        assert str(Path("0002_AA_2020-01-16_091500Z.mhl")) in fileContents
-        assert str(Path("B/ascmhl/0002_B_2020-01-16_091500Z.mhl")) in fileContents
-        assert str(Path("AA1.txt")) not in fileContents
-        assert str(Path("C1.txt")) in fileContents
+        assert "0002_AA_2020-01-16_091500Z.mhl" in fileContents
+        assert "B/ascmhl/0002_B_2020-01-16_091500Z.mhl" in fileContents
+        assert "AA1.txt" not in fileContents
+        assert "C1.txt" in fileContents
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
 
@@ -136,10 +136,10 @@ def test_create_nested_mhl_file_missing(fs):
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
     with open("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl", "r") as fin:
         fileContents = fin.read()
-        assert str(Path("0002_AA_2020-01-16_091500Z.mhl")) in fileContents
-        assert str(Path("B/ascmhl/0002_B_2020-01-16_091500Z.mhl")) in fileContents
-        assert str(Path("AA1.txt")) not in fileContents
-        assert str(Path("C1.txt")) in fileContents
+        assert "0002_AA_2020-01-16_091500Z.mhl" in fileContents
+        assert "B/ascmhl/0002_B_2020-01-16_091500Z.mhl" in fileContents
+        assert "AA1.txt" not in fileContents
+        assert "C1.txt" in fileContents
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
     remove_file = str(Path("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl"))

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -142,7 +142,7 @@ def test_create_nested_mhl_file_missing(fs):
         assert str(Path("C1.txt")) in fileContents
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
-    remove_file = "C:" + str(Path("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl"))
+    remove_file = str(Path("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl"))
     print(f"DBG: remove_file {remove_file}")
     os.remove(remove_file)
     result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,93 @@
+"""
+__author__ = "Patrick Renner"
+__copyright__ = "Copyright 2024, Pomfort GmbH"
+
+__license__ = "MIT"
+__maintainer__ = "Patrick Renner, Alexander Sahm"
+__email__ = "opensource@pomfort.com"
+"""
+
+import os
+from freezegun import freeze_time
+from click.testing import CliRunner
+
+from ascmhl.history import MHLHistory
+import ascmhl.commands
+from ascmhl.paths import _convert_local_to_xml_path, _detect_path_type, _convert_xml_to_local_path, _PathType
+
+from pathlib import Path, PurePosixPath, PureWindowsPath, PosixPath, WindowsPath
+import os
+
+
+def test_conversion_to_posix(fs):
+    windows_path = "\\foo\\bar\\test.txt"
+
+    converted_path = PureWindowsPath(windows_path).as_posix()
+
+    assert converted_path == "/foo/bar/test.txt"
+
+
+def test_conversion_to_windows(fs):
+    posix_path = "/foo/bar/test.txt"
+
+    converted_path = str(PureWindowsPath(PurePosixPath(posix_path)))
+
+    assert converted_path == "\\foo\\bar\\test.txt"
+
+
+def test_detect_path_type():
+
+    windows_path = "\\foo\\bar\\test.txt"
+    posix_path = "/foo/bar/test.txt"
+    mixed_path = "/foo/bar/test\\file.txt"
+    no_path = "file.txt"
+
+    assert _detect_path_type(windows_path) == _PathType.WINDOWS
+    assert _detect_path_type(posix_path) == _PathType.POSIX
+    assert _detect_path_type(mixed_path) == _PathType.MIXED
+    assert _detect_path_type(no_path) == _PathType.UNKNOWN
+
+
+def test_convert_to_xml_path():
+
+    windows_path = "\\foo\\bar\\test.txt"
+    posix_path = "/foo/bar/test.txt"
+
+    if os.name == "posix":
+        assert posix_path == _convert_local_to_xml_path(posix_path)
+        assert windows_path == _convert_local_to_xml_path(
+            posix_path, _xml_path_type=_PathType.WINDOWS
+        )  # not a real case, just for debugging
+    elif os.name == "nt":
+        assert posix_path == _convert_local_to_xml_path(windows_path)
+        assert windows_path == _convert_local_to_xml_path(windows_path)  # not a real case, just for debugging
+    else:
+        print(f"ERR: Unknown operating system: {os.name}")
+        assert 0
+
+
+def test_convert_xml_to_local_path():
+
+    windows_path = "\\foo\\bar\\test.txt"
+    posix_path = "/foo/bar/test.txt"
+
+    if os.name == "posix":
+        assert posix_path == _convert_xml_to_local_path(posix_path)
+        assert posix_path == _convert_xml_to_local_path(
+            windows_path, convert_from_windows_paths=True
+        )  # robustness for possibly wrong windows paths in XML
+        assert posix_path == _convert_xml_to_local_path(
+            posix_path, convert_from_windows_paths=True
+        )  # should still work
+    elif os.name == "nt":
+        assert windows_path == _convert_xml_to_local_path(posix_path)
+        assert windows_path == _convert_xml_to_local_path(
+            windows_path, convert_from_windows_paths=True
+        )  # robustness for possibly wrong windows paths in XML
+        assert windows_path == _convert_xml_to_local_path(
+            posix_path, convert_from_windows_paths=True
+        )  # should still work
+        assert 0
+    else:
+        print(f"ERR: Unknown operating system: {os.name}")
+        assert 0

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -60,7 +60,9 @@ def test_convert_to_xml_path():
         )  # not a real case, just for debugging
     elif os.name == "nt":
         assert posix_path == _convert_local_to_xml_path(windows_path)
-        assert windows_path == _convert_local_to_xml_path(windows_path)  # not a real case, just for debugging
+        assert windows_path == _convert_local_to_xml_path(
+            windows_path, _xml_path_type=_PathType.WINDOWS
+        )  # not a real case, just for debugging
     else:
         print(f"ERR: Unknown operating system: {os.name}")
         assert 0
@@ -87,7 +89,6 @@ def test_convert_xml_to_local_path():
         assert windows_path == _convert_xml_to_local_path(
             posix_path, convert_from_windows_paths=True
         )  # should still work
-        assert 0
     else:
         print(f"ERR: Unknown operating system: {os.name}")
         assert 0

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -34,6 +34,16 @@ def test_conversion_to_windows(fs):
 
     assert converted_path == "\\foo\\bar\\test.txt"
 
+def test_conversion_from_posix_to_local():
+    posix_path = "/foo/bar/test.txt"
+
+    converted_path = str(Path(posix_path))
+
+    if os.name == "posix":
+        assert converted_path == "/foo/bar/test.txt"
+    elif os.name == "nt":
+        assert converted_path == "\\foo\\bar\\test.txt"
+
 
 def test_detect_path_type():
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -34,6 +34,7 @@ def test_conversion_to_windows(fs):
 
     assert converted_path == "\\foo\\bar\\test.txt"
 
+
 def test_conversion_from_posix_to_local():
     posix_path = "/foo/bar/test.txt"
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -10,6 +10,7 @@ __email__ = "opensource@pomfort.com"
 import os
 from freezegun import freeze_time
 from click.testing import CliRunner
+from pathlib import Path
 
 from ascmhl.history import MHLHistory
 import ascmhl.commands
@@ -33,7 +34,7 @@ def test_record_succeed_single_file(fs):
     # make sure that only the specified file was added
     history = MHLHistory.load_from_path("/root")
     assert len(history.hash_lists[0].media_hashes) == 1
-    assert history.hash_lists[0].media_hashes[0].path == "A/A1.txt"
+    assert history.hash_lists[0].media_hashes[0].path == str(Path("A/A1.txt"))
 
 
 @freeze_time("2020-01-16 09:15:00")
@@ -51,8 +52,8 @@ def test_record_succeed_single_directory(fs):
     # make sure that only the specified file was added
     history = MHLHistory.load_from_path("/root")
     assert len(history.hash_lists[0].media_hashes) == 2
-    assert history.hash_lists[0].media_hashes[0].path == "A/A1.txt"
-    assert history.hash_lists[0].media_hashes[1].path == "A/A2.txt"
+    assert history.hash_lists[0].media_hashes[0].path == str(Path("A/A1.txt"))
+    assert history.hash_lists[0].media_hashes[1].path == str(Path("A/A2.txt"))
 
 
 @freeze_time("2020-01-16 09:15:00")
@@ -70,8 +71,8 @@ def test_record_succeed_multiple_files(fs):
     # make sure that only the specified file was added
     history = MHLHistory.load_from_path("/root")
     assert len(history.hash_lists[0].media_hashes) == 2
-    assert history.hash_lists[0].media_hashes[0].path == "A/A1.txt"
-    assert history.hash_lists[0].media_hashes[1].path == "A/A2.txt"
+    assert history.hash_lists[0].media_hashes[0].path == str(Path("A/A1.txt"))
+    assert history.hash_lists[0].media_hashes[1].path == str(Path("A/A2.txt"))
 
 
 def test_record_fail_altered_file(fs, simple_mhl_history):
@@ -91,7 +92,7 @@ def test_record_fail_altered_file(fs, simple_mhl_history):
 
     # make sure we have created one failing and one succeeded generation
     history = MHLHistory.load_from_path("/root")
-    assert history.hash_lists[1].media_hashes[0].path == "Stuff.txt"
+    assert history.hash_lists[1].media_hashes[0].path == str(Path("Stuff.txt"))
     assert history.hash_lists[1].media_hashes[0].hash_entries[0].action == "failed"
-    assert history.hash_lists[2].media_hashes[0].path == "A/A1.txt"
+    assert history.hash_lists[2].media_hashes[0].path == str(Path("A/A1.txt"))
     assert history.hash_lists[2].media_hashes[0].hash_entries[0].action == "verified"

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -14,6 +14,7 @@ import os
 import shutil
 from importlib import reload
 from typing import List
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -173,10 +174,10 @@ def compare_files_against_reference(scenario_reference: str, folder_paths: List[
 
 def validate_all_mhl_files_against_xml_schema(folder_path: str):
     """Find all mhl files created and validate them against the xsd"""
-    mhl_files = glob.glob(folder_path + r"/**/*.mhl", recursive=True)
+    mhl_files = glob.glob(str(Path(folder_path + r"/**/*.mhl")), recursive=True)
     runner = CliRunner()
     for file in mhl_files:
-        result = runner.invoke(ascmhl.commands.xsd_schema_check, file)
+        result = runner.invoke(ascmhl.commands.xsd_schema_check, Path(file).as_posix())
         assert result.exit_code == 0, result.output
 
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -28,7 +28,7 @@ def test_simple_verify_fails_no_history(fs, simple_mhl_history):
 def test_simple_verify(fs, simple_mhl_history):
     runner = CliRunner()
     result = runner.invoke(ascmhl.commands.verify, ["-v", str(Path("/root/"))])
-    #print(f"DBG: result.output {result.output}")
+    # print(f"DBG: result.output {result.output}")
     assert (
         result.output
         == "check folder at path: /root\nverification (xxh64) of file A/A1.txt: OK\nverification (xxh64) of file"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -10,6 +10,7 @@ __email__ = "opensource@pomfort.com"
 import os
 from freezegun import freeze_time
 from click.testing import CliRunner
+from pathlib import Path
 
 from ascmhl.history import MHLHistory
 import ascmhl.commands
@@ -26,10 +27,11 @@ def test_simple_verify_fails_no_history(fs, simple_mhl_history):
 @freeze_time("2020-01-16 09:15:00")
 def test_simple_verify(fs, simple_mhl_history):
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.verify, ["-v", "/root/"])
+    result = runner.invoke(ascmhl.commands.verify, ["-v", str(Path("/root/"))])
+    #print(f"DBG: result.output {result.output}")
     assert (
         result.output
-        == "check folder at path: /root/\nverification (xxh64) of file A/A1.txt: OK\nverification (xxh64) of file"
+        == "check folder at path: /root\nverification (xxh64) of file A/A1.txt: OK\nverification (xxh64) of file"
         " Stuff.txt: OK\n"
     )
     assert result.exit_code == 0


### PR DESCRIPTION
* Handling windows path and writing them properly into the history MHL files (i.e. `as_posix()`)
* Fixing a lot of tests for Windows
* Adding a new option `-cvp` that allows to verify ASC MHL XML files with (wrong) Windows paths on Posix systems