### PR TITLE
Make sure to properly read and write posix style relative paths to the xml files on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# make sure the scenario output files are not converted to a different line ending when checked out by git on windows
+# otherwise the scenario tests will fail and the files can't be verified with the ascmhl tool
+/examples/scenarios/Output/** binary

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -5,7 +5,7 @@ name: ascmhl-build-test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev/windowsPathHandling ]
   pull_request:
     branches: [ master ]
 
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12"]
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/build
 docs/docenv
 .coverage
 htmlcov
+/.vscode/

--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -1263,12 +1263,18 @@ def info(verbose, single_file, root_path):
     if single_file is not None and len(single_file) > 0:
         if root_path == None:
             current_dir = os.path.dirname(os.path.abspath(single_file[0]))
-            while current_dir != "/" and current_dir != "":
+            while os.path.isdir(current_dir):
                 asc_mhl_folder_path = os.path.join(current_dir, ascmhl_folder_name)
                 if os.path.exists(asc_mhl_folder_path):
                     root_path = current_dir
                     break
-                current_dir = os.path.dirname(current_dir)
+                parent_dir = os.path.dirname(current_dir)
+                # in case we get the same path again, we seem to be at the root
+                # this works both on windows and unix
+                if parent_dir == current_dir:
+                    break
+                current_dir = parent_dir
+
         if root_path is None:
             raise errors.NoMHLHistoryException(single_file[0])
         else:
@@ -1405,6 +1411,7 @@ def xsd_schema_check(file_path, directory_file, xsd_file):
     # pass a file handle to support the fake file system used in the tests
     file = open(file_path, "rb")
     result = xsd.validate(etree.parse(file))
+    file.close()
 
     if result:
         logger.info(f"validated: {file_path}")

--- a/ascmhl/hashlist.py
+++ b/ascmhl/hashlist.py
@@ -260,7 +260,7 @@ class MHLCreatorInfo:
 
     host_name: Optional[str]
     tool: Optional[MHLTool]
-    creation_date: Optional[datetime]
+    creation_date: Optional[str]
     authors: List[MHLAuthor]
     location: Optional[str]
     comment: Optional[str]

--- a/ascmhl/utils.py
+++ b/ascmhl/utils.py
@@ -9,6 +9,8 @@ __email__ = "opensource@pomfort.com"
 
 import datetime
 import time
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
 def matches_prefixes(text: str, prefixes: list):
@@ -26,7 +28,7 @@ def datetime_isostring(date, keep_microseconds=False):
     date -- date object
     keep_microseconds -- include microseconds in iso
     """
-    utc_offset_sec = time.altzone if time.localtime().tm_isdst else time.timezone
+    utc_offset_sec = time.altzone if time.localtime().tm_isdst == 1 else time.timezone
     utc_offset = datetime.timedelta(seconds=-utc_offset_sec)
 
     if keep_microseconds:
@@ -43,8 +45,18 @@ def datetime_now_isostring():
 
 def datetime_now_filename_string():
     """create a string representation for now() for use as part of the MHL filename"""
-    return datetime.datetime.strftime(datetime.datetime.now(datetime.UTC), "%Y-%m-%d_%H%M%SZ")
+    return datetime.datetime.strftime(datetime.datetime.now(datetime.timezone.utc), "%Y-%m-%d_%H%M%SZ")
 
 
 def datetime_now_isostring_with_microseconds():
     return datetime_isostring(datetime.datetime.now(), keep_microseconds=True)
+
+
+def convert_local_path_to_posix(path: str) -> str:
+    return str(Path(path).as_posix())
+
+
+def convert_posix_to_local_path(path: str) -> str:
+    if os.name == "nt":
+        return str(PureWindowsPath(PurePosixPath(path)))
+    return path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,22 @@ __email__ = "opensource@pomfort.com"
 import pytest
 from freezegun import freeze_time
 from click.testing import CliRunner
+from os.path import abspath
+from pathlib import Path
 import ascmhl.commands
 import os
 import time
 import platform
 
 # this file is automatically loaded by pytest we setup various shared fixtures here
+
+
+def abspath_conversion_tests(path):
+    return abspath(path)
+
+
+def path_conversion_tests(path):
+    return Path(path)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -44,21 +54,21 @@ def nested_mhl_histories(fs):
     # create mhl histories on different directly levels
     fs.create_file("/root/Stuff.txt", contents="stuff\n")
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64"])
     assert result.exit_code == 0
 
     fs.create_file("/root/A/AA/AA1.txt", contents="AA1\n")
     fs.create_file("/root/A/AB/AB1.txt", contents="AB1\n")
-    result = runner.invoke(ascmhl.commands.create, ["/root/A/AA", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/A/AA"), "-h", "xxh64"])
     assert result.exit_code == 0
 
     fs.create_file("/root/B/B1.txt", contents="B1\n")
-    result = runner.invoke(ascmhl.commands.create, ["/root/B", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/B"), "-h", "xxh64"])
     assert result.exit_code == 0
 
     fs.create_file("/root/B/BA/BA1.txt", contents="BA1\n")
     fs.create_file("/root/B/BB/BB1.txt", contents="BB1\n")
-    result = runner.invoke(ascmhl.commands.create, ["/root/B/BB", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/B/BB"), "-h", "xxh64"])
     assert result.exit_code == 0
 
 
@@ -70,7 +80,7 @@ def simple_mhl_history(fs):
     fs.create_file("/root/A/A1.txt", contents="A1\n")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64"])
     assert result.exit_code == 0
 
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -9,13 +9,14 @@ __email__ = "opensource@pomfort.com"
 
 import os
 from click.testing import CliRunner
+from .conftest import abspath_conversion_tests
 
 import ascmhl.commands
 
 
 def test_check_succeed(fs, simple_mhl_history):
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert result.exit_code == 0
 
 
@@ -23,9 +24,9 @@ def test_check_fail_missing_history(fs):
     fs.create_file("/root/Stuff.txt", contents="stuff\n")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert result.exit_code == 30
-    assert "/root" in result.output
+    assert abspath_conversion_tests("/root") in result.output
 
 
 def test_check_fail_altered_file(fs, simple_mhl_history):
@@ -34,7 +35,7 @@ def test_check_fail_altered_file(fs, simple_mhl_history):
         file.write("!!")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert result.exit_code == 11
     assert "Stuff.txt" in result.output
 
@@ -43,7 +44,7 @@ def test_check_fail_new_file(fs, simple_mhl_history):
     # create a file not referenced in the history
     fs.create_file("/root/other.txt", contents="other\n")
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert result.exit_code == 21
     assert "other.txt" in result.output
 
@@ -53,6 +54,6 @@ def test_check_fail_missing_file(fs, simple_mhl_history):
     os.remove("/root/Stuff.txt")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert result.exit_code == 10
     assert "Stuff.txt" in result.output

--- a/tests/test_dirhash.py
+++ b/tests/test_dirhash.py
@@ -10,6 +10,7 @@ __email__ = "opensource@pomfort.com"
 import os
 from click.testing import CliRunner
 from freezegun import freeze_time
+from .conftest import abspath_conversion_tests
 
 import ascmhl.commands
 
@@ -17,7 +18,7 @@ import ascmhl.commands
 @freeze_time("2020-01-16 09:15:00")
 def test_simple(fs, simple_mhl_history):
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.verify, ["-dh", "-co", "/root/"])
+    result = runner.invoke(ascmhl.commands.verify, ["-dh", "-co", abspath_conversion_tests("/root")])
     assert (
         "calculated directory hash for A  xxh64: d3904ee76bba3d2a (content), 3fbe33b2924e26aa (structure)"
         in result.output
@@ -25,7 +26,7 @@ def test_simple(fs, simple_mhl_history):
     assert "calculated root hash  xxh64: ca56d22f064fdf1b (content), 2ccca3899111eabb (structure)" in result.output
     assert result.exit_code == 0
 
-    result = runner.invoke(ascmhl.commands.verify, ["-dh", "-co", "-ro", "/root/"])
+    result = runner.invoke(ascmhl.commands.verify, ["-dh", "-co", "-ro", abspath_conversion_tests("/root")])
     assert "calculated directory hash" not in result.output
     assert "calculated root hash  xxh64: ca56d22f064fdf1b (content), 2ccca3899111eabb (structure)" in result.output
     assert result.exit_code == 0

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -10,6 +10,7 @@ __email__ = "opensource@pomfort.com"
 import os
 from click.testing import CliRunner
 from freezegun import freeze_time
+from .conftest import abspath_conversion_tests
 
 import ascmhl.commands
 
@@ -17,7 +18,9 @@ import ascmhl.commands
 @freeze_time("2020-01-16 09:15:00")
 def test_simple(fs, simple_mhl_history):
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.flatten, ["/root/", "/out/"])
+    result = runner.invoke(
+        ascmhl.commands.flatten, [abspath_conversion_tests("/root"), abspath_conversion_tests("/out")]
+    )
     assert result.exit_code == 0
 
 
@@ -28,9 +31,11 @@ def test_add_one_file_same_hashformat(fs, simple_mhl_history):
     # add a sidecar
     fs.create_file("/root/sidecar.txt", contents="sidecar\n")
     runner = CliRunner()
-    runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64"])
+    runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64"])
 
-    result = runner.invoke(ascmhl.commands.flatten, ["/root/", "/out/"])
+    result = runner.invoke(
+        ascmhl.commands.flatten, [abspath_conversion_tests("/root"), abspath_conversion_tests("/out")]
+    )
     assert result.exit_code == 0
 
 
@@ -40,7 +45,9 @@ def test_simple_two_hashformats(fs, simple_mhl_history):
 
     # add a sidecar
     runner = CliRunner()
-    runner.invoke(ascmhl.commands.create, ["/root", "-h", "md5"])
+    runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "md5"])
 
-    result = runner.invoke(ascmhl.commands.flatten, ["/root/", "/out/"])
+    result = runner.invoke(
+        ascmhl.commands.flatten, [abspath_conversion_tests("/root"), abspath_conversion_tests("/out")]
+    )
     assert result.exit_code == 0

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -10,6 +10,7 @@ __email__ = "opensource@pomfort.com"
 import os
 from click.testing import CliRunner
 from freezegun import freeze_time
+from .conftest import abspath_conversion_tests
 
 import ascmhl.commands
 
@@ -18,17 +19,17 @@ import ascmhl.commands
 def test_simple_info_fails_no_history(fs, simple_mhl_history):
     runner = CliRunner()
     os.rename("/root/ascmhl", "/root/_ascmhl")
-    result = runner.invoke(ascmhl.commands.info, ["-sf", "/root/Stuff.txt"])
+    result = runner.invoke(ascmhl.commands.info, ["-sf", abspath_conversion_tests("/root/Stuff.txt")])
     assert result.exit_code == 30
 
 
 @freeze_time("2020-01-16 09:15:00")
 def test_simple_info(fs, simple_mhl_history):
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.info, ["-sf", "/root/Stuff.txt"])
+    result = runner.invoke(ascmhl.commands.info, ["-sf", abspath_conversion_tests("/root/Stuff.txt")])
     assert (
         result.output
-        == "Info with history at path: /root\nStuff.txt:\n  Generation 1 (2020-01-15T13:00:00+00:00) xxh64:"
+        == f"Info with history at path: {abspath_conversion_tests('/root')}\nStuff.txt:\n  Generation 1 (2020-01-15T13:00:00+00:00) xxh64:"
         " 94c399c2a9a21f9a (original)\n"
     )
     assert result.exit_code == 0
@@ -37,12 +38,12 @@ def test_simple_info(fs, simple_mhl_history):
 @freeze_time("2020-01-16 09:15:00")
 def test_info(fs, simple_mhl_history):
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root/", "-h", "xxh64"])
-    result = runner.invoke(ascmhl.commands.create, ["/root/", "-h", "md5"])
-    result = runner.invoke(ascmhl.commands.create, ["/root/", "-h", "xxh64"])
-    result = runner.invoke(ascmhl.commands.info, ["-sf", "/root/Stuff.txt"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "md5"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.info, ["-sf", abspath_conversion_tests("/root/Stuff.txt")])
     assert (
-        result.output == "Info with history at path: /root\nStuff.txt:\n"
+        result.output == f"Info with history at path: {abspath_conversion_tests('/root')}\nStuff.txt:\n"
         "  Generation 1 (2020-01-15T13:00:00+00:00) xxh64: 94c399c2a9a21f9a (original)\n"
         "  Generation 2 (2020-01-16T09:15:00+00:00) xxh64: 94c399c2a9a21f9a (verified)\n"
         "  Generation 3 (2020-01-16T09:15:00+00:00) md5: 9eb84090956c484e32cb6c08455a667b (verified)\n"
@@ -57,14 +58,14 @@ def test_altered_file(fs, simple_mhl_history):
     # alter a file
     with open("/root/Stuff.txt", "a") as file:
         file.write("!!")
-    CliRunner().invoke(ascmhl.commands.create, ["/root"])
-    CliRunner().invoke(ascmhl.commands.create, ["/root", "-h", "md5"])
+    CliRunner().invoke(ascmhl.commands.create, [abspath_conversion_tests("/root")])
+    CliRunner().invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "md5"])
 
     runner = CliRunner()
     result = runner.invoke(ascmhl.commands.info, ["-sf", "/root/Stuff.txt"])
     assert (
         result.output
-        == "Info with history at path: /root\nStuff.txt:\n  Generation 1 (2020-01-15T13:00:00+00:00) xxh64:"
+        == f"Info with history at path: {abspath_conversion_tests('/root')}\nStuff.txt:\n  Generation 1 (2020-01-15T13:00:00+00:00) xxh64:"
         " 94c399c2a9a21f9a (original)\n  Generation 2 (2020-01-16T09:15:00+00:00) xxh64: 2346e97eb08788cc (failed)\n"
         "  Generation 3 (2020-01-16T09:15:00+00:00) xxh64: 2346e97eb08788cc (failed)\n"
     )
@@ -73,13 +74,13 @@ def test_altered_file(fs, simple_mhl_history):
 
 @freeze_time("2020-01-16 09:15:00")
 def test_nested_info(fs, nested_mhl_histories):
-    CliRunner().invoke(ascmhl.commands.create, ["/root", "-h", "xxh64"])
-    CliRunner().invoke(ascmhl.commands.create, ["/root", "-h", "md5"])
+    CliRunner().invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64"])
+    CliRunner().invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "md5"])
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.info, ["-sf", "/root/Stuff.txt"])
+    result = runner.invoke(ascmhl.commands.info, ["-sf", abspath_conversion_tests("/root/Stuff.txt")])
     assert (
-        result.output == "Info with history at path: /root\nStuff.txt:\n"
+        result.output == f"Info with history at path: {abspath_conversion_tests('/root')}\nStuff.txt:\n"
         "  Generation 1 (2020-01-15T13:00:00+00:00) xxh64: 94c399c2a9a21f9a (original)\n"
         "  Generation 2 (2020-01-16T09:15:00+00:00) xxh64: 94c399c2a9a21f9a (verified)\n"
         "  Generation 3 (2020-01-16T09:15:00+00:00) md5: 9eb84090956c484e32cb6c08455a667b (verified)\n"

--- a/tests/test_mhl_parsing.py
+++ b/tests/test_mhl_parsing.py
@@ -9,10 +9,14 @@ __email__ = "opensource@pomfort.com"
 
 import os
 import re
+from .conftest import abspath_conversion_tests
+
 from freezegun import freeze_time
 from click.testing import CliRunner
+from .conftest import path_conversion_tests
 
 from ascmhl import hashlist_xml_parser
+from ascmhl import utils
 from ascmhl.__version__ import ascmhl_file_extension
 from ascmhl.history import MHLHistory
 import ascmhl.commands
@@ -28,41 +32,41 @@ def test_simple_parsing():
 def test_child_history_parsing(fs, nested_mhl_histories):
     """ """
 
-    root_history = MHLHistory.load_from_path("/root")
+    root_history = MHLHistory.load_from_path(abspath_conversion_tests("/root"))
     assert len(root_history.child_histories) == 2
 
     aa_history = root_history.child_histories[0]
     b_history = root_history.child_histories[1]
     bb_history = root_history.child_histories[1].child_histories[0]
 
-    assert aa_history.asc_mhl_path == "/root/A/AA/ascmhl"
+    assert aa_history.asc_mhl_path == abspath_conversion_tests("/root/A/AA/ascmhl")
     assert aa_history.parent_history == root_history
-    assert b_history.asc_mhl_path == "/root/B/ascmhl"
+    assert b_history.asc_mhl_path == abspath_conversion_tests("/root/B/ascmhl")
     assert b_history.parent_history == root_history
 
     assert len(b_history.child_histories) == 1
-    assert bb_history.asc_mhl_path == "/root/B/BB/ascmhl"
+    assert bb_history.asc_mhl_path == abspath_conversion_tests("/root/B/BB/ascmhl")
     assert bb_history.parent_history == b_history
 
     # check sub children mappings that map all transitive children and their relative path
-    assert root_history.child_history_mappings["A/AA"] == aa_history
-    assert root_history.child_history_mappings["B"] == b_history
-    assert root_history.child_history_mappings["B/BB"] == bb_history
-    assert b_history.child_history_mappings["BB"] == bb_history
+    assert root_history.child_history_mappings[str(path_conversion_tests("A/AA"))] == aa_history
+    assert root_history.child_history_mappings[str(path_conversion_tests("B"))] == b_history
+    assert root_history.child_history_mappings[str(path_conversion_tests("B/BB"))] == bb_history
+    assert b_history.child_history_mappings[str(path_conversion_tests("BB"))] == bb_history
 
     # check if the correct (child) histories are returned for a given path
-    assert root_history.find_history_for_path("Stuff.txt")[0] == root_history
-    assert root_history.find_history_for_path("A/AA/AA1.txt")[0] == aa_history
-    assert root_history.find_history_for_path("A/AB/AB1.txt")[0] == root_history
-    assert root_history.find_history_for_path("B/B1.txt")[0] == b_history
-    assert root_history.find_history_for_path("B/BA/BA1.txt")[0] == b_history
-    assert root_history.find_history_for_path("B/BB/BB1.txt")[0] == bb_history
-    assert root_history.find_history_for_path("B")[0] == b_history
+    assert root_history.find_history_for_path(str(path_conversion_tests("Stuff.txt")))[0] == root_history
+    assert root_history.find_history_for_path(str(path_conversion_tests("A/AA/AA1.txt")))[0] == aa_history
+    assert root_history.find_history_for_path(str(path_conversion_tests("A/AB/AB1.txt")))[0] == root_history
+    assert root_history.find_history_for_path(str(path_conversion_tests("B/B1.txt")))[0] == b_history
+    assert root_history.find_history_for_path(str(path_conversion_tests("B/BA/BA1.txt")))[0] == b_history
+    assert root_history.find_history_for_path(str(path_conversion_tests("B/BB/BB1.txt")))[0] == bb_history
+    assert root_history.find_history_for_path(str(path_conversion_tests("B")))[0] == b_history
 
     # the history object should only return the media hashes and hash entries it contains directly
     # if we need th entries from child histories we have to ask them directly
     assert root_history.find_original_hash_entry_for_path("Stuff.txt") is not None
-    assert root_history.find_original_hash_entry_for_path("A/AA/AA1.txt") is None
+    assert root_history.find_original_hash_entry_for_path(str(path_conversion_tests("A/AA/AA1.txt"))) is None
     assert aa_history.find_original_hash_entry_for_path("AA1.txt") is not None
 
 
@@ -71,7 +75,7 @@ def test_child_history_verify(fs, nested_mhl_histories):
     """ """
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root"], catch_exceptions=False)
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root")], catch_exceptions=False)
     assert result.exit_code == 0
 
     assert os.path.isfile("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
@@ -79,10 +83,10 @@ def test_child_history_verify(fs, nested_mhl_histories):
     assert os.path.isfile("/root/B/ascmhl/0002_B_2020-01-16_091500Z.mhl")
     assert os.path.isfile("/root/B/BB/ascmhl/0002_BB_2020-01-16_091500Z.mhl")
 
-    root_history = MHLHistory.load_from_path("/root")
+    root_history = MHLHistory.load_from_path(abspath_conversion_tests("/root"))
     assert len(root_history.hash_lists) == 2
 
-    assert root_history.hash_lists[1].media_hashes[1].path == "A/AB/AB1.txt"
+    assert root_history.hash_lists[1].media_hashes[1].path == str(path_conversion_tests("A/AB/AB1.txt"))
     assert root_history.hash_lists[1].media_hashes[1].hash_entries[0].action == "original"
     assert root_history.hash_lists[1].media_hashes[5].path == "Stuff.txt"
     assert root_history.hash_lists[1].media_hashes[5].hash_entries[0].action == "verified"
@@ -96,7 +100,7 @@ def test_child_history_verify(fs, nested_mhl_histories):
     bb_hash_list = bb_history.hash_lists[-1]
 
     assert aa_history.latest_generation_number() == 2
-    assert b_hash_list.media_hashes[0].path == "BA/BA1.txt"
+    assert b_hash_list.media_hashes[0].path == str(path_conversion_tests("BA/BA1.txt"))
     assert b_hash_list.media_hashes[3].path == "B1.txt"
     assert b_hash_list.media_hashes[0].hash_entries[0].action == "original"
     assert b_hash_list.media_hashes[3].hash_entries[0].action == "verified"
@@ -109,11 +113,13 @@ def test_child_history_verify(fs, nested_mhl_histories):
 
     # the media hashes of the directories that contain a history themselves should be both in the child history
     # as root media hash and in the parent history to represent the directory that contains the child history
-    aa_dir_hash = root_hash_list.find_media_hash_for_path("A/AA").hash_entries[0].hash_string
+    aa_dir_hash = (
+        root_hash_list.find_media_hash_for_path(str(path_conversion_tests("A/AA"))).hash_entries[0].hash_string
+    )
     assert aa_dir_hash
     assert aa_hash_list.process_info.root_media_hash.hash_entries[0].hash_string == aa_dir_hash
     # the dir hash of BB is in the history of B not in the root history
-    assert root_hash_list.find_media_hash_for_path("B/BB") is None
+    assert root_hash_list.find_media_hash_for_path(str(path_conversion_tests("B/BB"))) is None
     bb_dir_hash = b_hash_list.find_media_hash_for_path("BB").hash_entries[0].hash_string
     assert bb_hash_list.process_info.root_media_hash.hash_entries[0].hash_string == bb_dir_hash
     # but the dir hash of B is also in the root history
@@ -127,14 +133,18 @@ def test_child_history_partial_verification_ba_1_file(fs, nested_mhl_histories):
     # create an additional file the record command will not add since we only pass it B1 as single file
     fs.create_file("/root/B/B2.txt", contents="B2\n")
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-sf", "/root/B/B1.txt"], catch_exceptions=False)
+    result = runner.invoke(
+        ascmhl.commands.create,
+        [abspath_conversion_tests("/root"), "-sf", abspath_conversion_tests("/root/B/B1.txt")],
+        catch_exceptions=False,
+    )
     assert result.exit_code == 0
 
     # two new generations have been written
     assert os.path.isfile("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
     assert os.path.isfile("/root/B/ascmhl/0002_B_2020-01-16_091500Z.mhl")
 
-    root_history = MHLHistory.load_from_path("/root")
+    root_history = MHLHistory.load_from_path(abspath_conversion_tests("/root"))
     assert len(root_history.hash_lists) == 2
 
     aa_history = root_history.child_histories[0]
@@ -164,14 +174,16 @@ def test_child_history_partial_verification_bb_folder(fs, nested_mhl_histories):
     # create an additional file the record command will find because we pass it a folder
     fs.create_file("/root/B/BB/BB2.txt", contents="BB2\n")
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-sf", "/root/B/BB"])
+    result = runner.invoke(
+        ascmhl.commands.create, [abspath_conversion_tests("/root"), "-sf", abspath_conversion_tests("/root/B/BB")]
+    )
     assert result.exit_code == 0
 
     assert os.path.isfile("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
     assert os.path.isfile("/root/B/ascmhl/0002_B_2020-01-16_091500Z.mhl")
     assert os.path.isfile("/root/B/BB/ascmhl/0002_BB_2020-01-16_091500Z.mhl")
 
-    root_history = MHLHistory.load_from_path("/root")
+    root_history = MHLHistory.load_from_path(abspath_conversion_tests("/root"))
     assert len(root_history.hash_lists) == 2
 
     aa_history = root_history.child_histories[0]

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -8,6 +8,9 @@ __email__ = "opensource@pomfort.com"
 """
 
 import os
+from .conftest import abspath_conversion_tests
+from .conftest import path_conversion_tests
+
 from click.testing import CliRunner
 from freezegun import freeze_time
 
@@ -25,17 +28,17 @@ def test_create_nested_succeed(fs):
     os.mkdir("/root/emptyFolderA")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root/A/AA", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/A/AA"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/A/AA/ascmhl/ascmhl_chain.xml")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root/B", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/B"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/B/ascmhl/0001_B_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/B/ascmhl/ascmhl_chain.xml")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/A/AA/ascmhl/0002_AA_2020-01-16_091500Z.mhl")
@@ -48,7 +51,7 @@ def test_create_nested_succeed(fs):
         assert "C1.txt" in fileContents
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/A/AA/ascmhl/0003_AA_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
@@ -59,8 +62,8 @@ def test_create_nested_succeed(fs):
         assert "AA2.txt" not in fileContents
 
     # test history command
-    result = runner.invoke(ascmhl.commands.info, ["/root"])
-    assert "Child History at /root/A/AA:" in result.output
+    result = runner.invoke(ascmhl.commands.info, [abspath_conversion_tests("/root")])
+    assert f"Child History at {abspath_conversion_tests('/root/A/AA')}:" in result.output
     assert result.output.count("Generation 3") == 2
     assert result.output.count("Generation 2") == 3
 
@@ -76,17 +79,17 @@ def test_create_nested_mhl_file_modified(fs):
     os.mkdir("/root/emptyFolderA")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root/A/AA", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/A/AA"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/A/AA/ascmhl/ascmhl_chain.xml")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root/B", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/B"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/B/ascmhl/0001_B_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/B/ascmhl/ascmhl_chain.xml")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/A/AA/ascmhl/0002_AA_2020-01-16_091500Z.mhl")
@@ -102,7 +105,7 @@ def test_create_nested_mhl_file_modified(fs):
 
     with open("/root/A/AA/ascmhl/0002_AA_2020-01-16_091500Z.mhl", "a") as mhl_file:
         mhl_file.write("changed content")
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert result.exception
     assert result.exit_code == 31
 
@@ -118,17 +121,17 @@ def test_create_nested_mhl_file_missing(fs):
     os.mkdir("/root/emptyFolderA")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root/A/AA", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/A/AA"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/A/AA/ascmhl/ascmhl_chain.xml")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root/B", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/B"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/B/ascmhl/0001_B_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/B/ascmhl/ascmhl_chain.xml")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/A/AA/ascmhl/0002_AA_2020-01-16_091500Z.mhl")
@@ -143,11 +146,11 @@ def test_create_nested_mhl_file_missing(fs):
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
 
     os.remove("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl")
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert result.exception
     assert result.exit_code == 33
 
-    result = runner.invoke(ascmhl.commands.diff, ["/root"])
+    result = runner.invoke(ascmhl.commands.diff, [abspath_conversion_tests("/root")])
     assert result.exception
     assert result.exit_code == 33
 
@@ -163,17 +166,17 @@ def test_create_nested_mhl_chain_missing(fs):
     os.mkdir("/root/emptyFolderA")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root/A/AA", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/A/AA"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/A/AA/ascmhl/0001_AA_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/A/AA/ascmhl/ascmhl_chain.xml")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root/B", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/B"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/B/ascmhl/0001_B_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/B/ascmhl/ascmhl_chain.xml")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/A/AA/ascmhl/0002_AA_2020-01-16_091500Z.mhl")
@@ -187,10 +190,10 @@ def test_create_nested_mhl_chain_missing(fs):
 
     fs.create_file("/root/A/AA/AA2.txt", contents="AA2\n")
     os.remove("/root/A/AA/ascmhl/ascmhl_chain.xml")
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert result.exception
     assert result.exit_code == 32
 
-    result = runner.invoke(ascmhl.commands.diff, ["/root"])
+    result = runner.invoke(ascmhl.commands.diff, [abspath_conversion_tests("/root")])
     assert result.exception
     assert result.exit_code == 32

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,96 @@
+"""
+__author__ = "Patrick Renner"
+__copyright__ = "Copyright 2024, Pomfort GmbH"
+
+__license__ = "MIT"
+__maintainer__ = "Patrick Renner, Alexander Sahm"
+__email__ = "opensource@pomfort.com"
+"""
+
+from .conftest import abspath_conversion_tests
+from ascmhl.utils import convert_local_path_to_posix, convert_posix_to_local_path
+
+from pathlib import PurePosixPath, PureWindowsPath
+from .conftest import path_conversion_tests
+import os
+
+
+def test_conversion_to_posix(fs):
+    windows_path = "\\foo\\bar\\test.txt"
+
+    converted_path = PureWindowsPath(windows_path).as_posix()
+
+    assert converted_path == "/foo/bar/test.txt"
+
+
+def test_conversion_to_windows(fs):
+    posix_path = "/foo/bar/test.txt"
+
+    converted_path = str(PureWindowsPath(PurePosixPath(posix_path)))
+
+    assert converted_path == "\\foo\\bar\\test.txt"
+
+
+def test_conversion_from_posix_to_local():
+    posix_path = "/foo/bar/test.txt"
+
+    converted_path = str(path_conversion_tests(posix_path))
+    if os.name == "posix":
+        assert converted_path == posix_path
+    elif os.name == "nt":
+        assert converted_path == "\\foo\\bar\\test.txt"
+
+
+def test_abspath_from_posix():
+    # this test is only relevant on windows
+    if os.name != "nt":
+        return
+
+    posix_path = "/foo/bar/test.txt"
+    previous_cwd = os.getcwd()
+
+    # the assumed drive depends on the working directory
+    os.chdir("C:\\")
+    converted_path = abspath_conversion_tests(posix_path)
+    if os.name == "posix":
+        assert converted_path == posix_path
+    elif os.name == "nt":
+        assert converted_path == "C:\\foo\\bar\\test.txt"
+
+    os.chdir("D:\\")
+    converted_path = abspath_conversion_tests(posix_path)
+    if os.name == "posix":
+        assert converted_path == posix_path
+    elif os.name == "nt":
+        assert converted_path == "D:\\foo\\bar\\test.txt"
+
+    # restore the working directory to avoid influencing other tests
+    os.chdir(previous_cwd)
+
+
+def test_convert_to_xml_path():
+
+    windows_path = "\\foo\\bar\\test.txt"
+    posix_path = "/foo/bar/test.txt"
+
+    if os.name == "posix":
+        assert posix_path == convert_local_path_to_posix(posix_path)
+    elif os.name == "nt":
+        assert posix_path == convert_local_path_to_posix(windows_path)
+    else:
+        print(f"ERR: Unknown operating system: {os.name}")
+        assert 0
+
+
+def test_convert_xml_to_local_path():
+
+    windows_path = "\\foo\\bar\\test.txt"
+    posix_path = "/foo/bar/test.txt"
+
+    if os.name == "posix":
+        assert posix_path == convert_posix_to_local_path(posix_path)
+    elif os.name == "nt":
+        assert windows_path == convert_posix_to_local_path(posix_path)
+    else:
+        print(f"ERR: Unknown operating system: {os.name}")
+        assert 0

--- a/tests/test_renaming.py
+++ b/tests/test_renaming.py
@@ -8,6 +8,8 @@ __email__ = "opensource@pomfort.com"
 """
 
 import os
+from .conftest import abspath_conversion_tests
+
 from click.testing import CliRunner
 from freezegun import freeze_time
 
@@ -23,12 +25,12 @@ def test_verify_renamed_files(fs):
     fs.create_file("/root/A/AA/AA1.txt", contents="AA1\n")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert not result.exception
 
     os.rename("/root/A/AA/AA1.txt", "/root/A/AA/AA1_renamed.txt")
@@ -57,10 +59,14 @@ def test_verify_renamed_files(fs):
         f.seek(0)
         f.writelines(contents)
 
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert not result.exception
 
-    result = runner.invoke(ascmhl.commands.info, ["-sf", "/root/A/AA/AA1_renamed.txt", "-v", "/root"])
+    result = runner.invoke(
+        ascmhl.commands.info,
+        ["-sf", abspath_conversion_tests("/root/A/AA/AA1_renamed.txt"), "-v", abspath_conversion_tests("/root")],
+    )
+
     assert not result.exception
     assert result.output.count("AA1.txt") == 3
     assert result.output.count("AA1_renamed.txt") == 3
@@ -75,12 +81,12 @@ def test_verify_renamed_file_but_also_changed_file(fs):
     fs.create_file("/root/A/AA/AA1.txt", contents="AA1\n")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert not result.exception
 
     os.rename("/root/A/AA/AA1.txt", "/root/A/AA/AA1_renamed.txt")
@@ -98,7 +104,7 @@ def test_verify_renamed_file_but_also_changed_file(fs):
         f.seek(0)
         f.writelines(contents)
 
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert result.exception
 
 
@@ -110,18 +116,18 @@ def test_detect_renamed_files(fs):
     fs.create_file("/root/A/AA/AA1.txt", contents="AA1\n")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert not result.exception
 
     os.rename("/root/A/AA/AA1.txt", "/root/A/AA/AA1_renamed.txt")
     fs.create_file("/root/B/B2.txt", contents="B2\n")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v", "-dr"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v", "-dr"])
     assert not result.exception
 
     with open("/root/ascmhl/0003_root_2020-01-16_091500Z.mhl", "r") as fin:
@@ -130,11 +136,11 @@ def test_detect_renamed_files(fs):
         assert "AA1.txt" in fileContents
         assert "AA1_renamed.txt" in fileContents
 
-    result = runner.invoke(ascmhl.commands.verify, ["/root", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root"), "-h", "xxh64"])
     assert not result.exception
 
     os.rename("/root/A/AA/AA1_renamed.txt", "/root/A/AA/AA1.txt")
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v", "-dr"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v", "-dr"])
     assert not result.exception
 
 
@@ -146,18 +152,18 @@ def test_detect_renamed_files_different_hash(fs):
     fs.create_file("/root/A/AA/AA1.txt", contents="AA1\n")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert not result.exception
 
     os.rename("/root/A/AA/AA1.txt", "/root/A/AA/AA1_renamed.txt")
     fs.create_file("/root/B/B2.txt", contents="B2\n")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-dr"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-v", "-dr"])
     assert not result.exception
 
     with open("/root/ascmhl/0003_root_2020-01-16_091500Z.mhl", "r") as fin:
@@ -166,7 +172,7 @@ def test_detect_renamed_files_different_hash(fs):
         assert "AA1.txt" in fileContents
         assert "AA1_renamed.txt" in fileContents
 
-    result = runner.invoke(ascmhl.commands.verify, ["/root", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root"), "-h", "xxh64"])
     assert not result.exception
 
 
@@ -178,18 +184,18 @@ def test_detect_renamed_files_different_hash(fs):
     fs.create_file("/root/A/AA/AA1.txt", contents="AA1\n")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert not result.exception
 
     os.rename("/root/A/AA/AA1.txt", "/root/A/AA/AA1_renamed.txt")
     fs.create_file("/root/B/B2.txt", contents="B2\n")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-v", "-dr"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-v", "-dr"])
     assert not result.exception
 
     with open("/root/ascmhl/0003_root_2020-01-16_091500Z.mhl", "r") as fin:
@@ -198,7 +204,7 @@ def test_detect_renamed_files_different_hash(fs):
         assert "AA1.txt" in fileContents
         assert "AA1_renamed.txt" in fileContents
 
-    result = runner.invoke(ascmhl.commands.verify, ["/root", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root"), "-h", "xxh64"])
     assert not result.exception
 
 
@@ -210,18 +216,18 @@ def test_do_not_detect_renamed_files(fs):
     fs.create_file("/root/A/AA/AA1.txt", contents="AA1\n")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0002_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert not result.exception
 
     os.rename("/root/A/AA/AA1.txt", "/root/A/AA/AA1_renamed.txt")
     fs.create_file("/root/B/B2.txt", contents="B2\n")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert result.exception
 
 
@@ -233,18 +239,18 @@ def test_detect_renamed_folders(fs):
     fs.create_file("/root/A/AA/AA1.txt", contents="AA1\n")
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root/A/AA", "-h", "xxh64", "-v"])
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root/A/AA"), "-h", "xxh64", "-v"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v"])
     assert not result.exception
     assert os.path.exists("/root/ascmhl/0001_root_2020-01-16_091500Z.mhl")
     assert os.path.exists("/root/ascmhl/ascmhl_chain.xml")
-    result = runner.invoke(ascmhl.commands.verify, ["/root"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root")])
     assert not result.exception
 
     os.rename("/root/A/AA", "/root/A/AB")
     os.rename("/root/A/AB/AA1.txt", "/root/A/AB/AA2.txt")
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v", "-dr"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v", "-dr"])
     assert not result.exception
     assert "a renamed" in result.output
 
@@ -252,9 +258,9 @@ def test_detect_renamed_folders(fs):
         fileContents = fin.read()
         assert fileContents.count("previousPath") == 2
 
-    result = runner.invoke(ascmhl.commands.verify, ["/root", "-h", "xxh64"])
+    result = runner.invoke(ascmhl.commands.verify, [abspath_conversion_tests("/root"), "-h", "xxh64"])
     assert not result.exception
 
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "xxh64", "-v", "-dr"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "xxh64", "-v", "-dr"])
     assert "a renamed" not in result.output
     assert not result.exception

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -13,9 +13,12 @@ import glob
 import os
 import shutil
 from importlib import reload
+from .conftest import abspath_conversion_tests
 from typing import List
+from .conftest import path_conversion_tests
 
 import pytest
+from ascmhl import utils
 from click.testing import CliRunner
 from freezegun import freeze_time
 from pyfakefs.fake_filesystem_unittest import Pause
@@ -95,7 +98,7 @@ def dirs_are_equal(dir1, dir2):
 
 def compare_dir_content(reference: str, dir_path: str) -> bool:
     if os.path.isabs(dir_path):
-        relative_path = dir_path.lstrip(os.sep)
+        relative_path = dir_path.lstrip("/")
     else:
         relative_path = dir_path
     ref_path = os.path.join(fake_ref_root_path, reference, relative_path)
@@ -173,10 +176,10 @@ def compare_files_against_reference(scenario_reference: str, folder_paths: List[
 
 def validate_all_mhl_files_against_xml_schema(folder_path: str):
     """Find all mhl files created and validate them against the xsd"""
-    mhl_files = glob.glob(folder_path + r"/**/*.mhl", recursive=True)
+    mhl_files = glob.glob(abspath_conversion_tests(folder_path) + r"/**/*.mhl", recursive=True)
     runner = CliRunner()
     for file in mhl_files:
-        result = runner.invoke(ascmhl.commands.xsd_schema_check, file)
+        result = runner.invoke(ascmhl.commands.xsd_schema_check, [file])
         assert result.exit_code == 0, result.output
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 from packaging import version
 
-from ascmhl.utils import datetime_now_filename_string
+from ascmhl.utils import datetime_now_filename_string, datetime_now_isostring
+from freezegun import freeze_time
 import datetime
 import os, time
 
@@ -8,7 +9,7 @@ import os, time
 def test_time():
     datetime_now_filename = datetime_now_filename_string()
     datetime_now_filename_reference = datetime.datetime.strftime(
-        datetime.datetime.now(datetime.UTC), "%Y-%m-%d_%H%M%SZ"
+        datetime.datetime.now(datetime.timezone.utc), "%Y-%m-%d_%H%M%SZ"
     )
 
     print("datetime_now_filename:           " + datetime_now_filename)
@@ -16,3 +17,9 @@ def test_time():
 
     # seems always to be working, as tests run in UTC ?
     assert datetime_now_filename == datetime_now_filename_reference
+
+
+@freeze_time("2020-01-15 13:00:00")
+def test_freeze_time():
+    iso_string = datetime_now_isostring()
+    assert iso_string == "2020-01-15T13:00:00+00:00"

--- a/tests/test_verify_nested.py
+++ b/tests/test_verify_nested.py
@@ -8,6 +8,8 @@ __email__ = "opensource@pomfort.com"
 """
 
 import os
+from .conftest import abspath_conversion_tests
+
 from freezegun import freeze_time
 from click.testing import CliRunner
 
@@ -35,5 +37,5 @@ def test_create_nested(fs, nested_mhl_histories):
     """
 
     runner = CliRunner()
-    result = runner.invoke(ascmhl.commands.create, ["/root", "-h", "md5"])
+    result = runner.invoke(ascmhl.commands.create, [abspath_conversion_tests("/root"), "-h", "md5"])
     assert result.exit_code == 0


### PR DESCRIPTION
On windows the tool should take and output windows style paths with backward slashes as path separators. But when writing the mhl file we should use forward slashes as specified in the specification.

We also can read and process mhl files with forward slashes on windows now.

The test cases have been adjusted to pass windows style paths as arguments and expect windows style paths in the output when running on windows.

To make sure the windows cases will work in the future we now also run them on a windows instance using GitHub actions.