### PR TITLE
Improving performance when verifying 1000s of files in one history

### DIFF
--- a/ascmhl/commands.py
+++ b/ascmhl/commands.py
@@ -251,9 +251,13 @@ def create_for_folder_subcommand(
             file_path = os.path.join(folder_path, item_name)
             not_found_paths.discard(file_path)
             for hash_list in existing_history.hash_lists:
-                for media_hash in hash_list.media_hashes:
-                    if media_hash.path == existing_history.get_relative_file_path(file_path):
-                        break
+                if detect_renaming:
+                    # this is quite costly, especially for 1000s of files <- the symptom is that the IO becomes slower and slower due to the fs system access for `get_relative_path``
+                    for media_hash in hash_list.media_hashes:
+                        if media_hash.path == existing_history.get_relative_file_path(file_path):
+                            break
+                    else:
+                        new_paths.add(file_path)
                 else:
                     new_paths.add(file_path)
             if is_dir:


### PR DESCRIPTION
Limiting a costly check to the renaming scenarios where it's needed.

The symptom was that the I/O speed on fast drives (for example, during the `create` command) got slower and slower after 1000s of files verified. This now only happens when the `-dr` option is set (where it's needed). 

No tests have been changed.